### PR TITLE
fix pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
 	<groupId>uk.co.caprica</groupId>
 	<artifactId>vlcj</artifactId>
-	<version>1.3.0</version>
+	<version>1.3.0-SNAPSHOT</version>
 
 	<name>vlcj</name>
 	<description>Java Framework for the vlc Media Player.</description>
@@ -78,7 +78,6 @@
 	</scm>
 
   	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<jna.version>3.4.0</jna.version>
 	</properties>
 
@@ -104,13 +103,23 @@
 
 	<build>
 		<plugins>
-			<plugin>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-				</configuration>
-			</plugin>
+		     <plugin>
+		       <groupId>org.apache.maven.plugins</groupId>
+		       <artifactId>maven-resources-plugin</artifactId>
+		       <version>2.4.3</version>
+		       <configuration>
+		         <encoding>UTF-8</encoding>
+		       </configuration>
+		     </plugin>
+		     <plugin>
+		       <artifactId>maven-compiler-plugin</artifactId>
+		       <version>2.3.2</version>
+		       <configuration>
+		         <source>1.6</source>
+		         <target>1.6</target>
+		         <encoding>UTF-8</encoding>
+		       </configuration>
+		     </plugin>
 		</plugins>
 		<extensions>
 			<extension>


### PR DESCRIPTION
since here is no relase named 1.3.0 maven suggest to keep version name with -SNAPSHOT prefix. it is better to keep this way since eclipse won't update stable style components from redownloading (1.3.0 - stable, 1.3.0-SNAPSHOT dev name).

after release, and tagging source you have to fix it back to 1.3.0. and then after tagging change it back to 1.4.0-SNAPSHOT.

and two changes to fix maven warnings.
