### PR TITLE
New DirectMediaPlayer (mostly compatible)

### DIFF
--- a/src/main/java/uk/co/caprica/vlcj/binding/internal/libvlc_lock_callback_t.java
+++ b/src/main/java/uk/co/caprica/vlcj/binding/internal/libvlc_lock_callback_t.java
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with VLCJ.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  * Copyright 2009, 2010, 2011, 2012 Caprica Software Limited.
  */
 
@@ -21,6 +21,7 @@ package uk.co.caprica.vlcj.binding.internal;
 
 import com.sun.jna.Callback;
 import com.sun.jna.Pointer;
+import com.sun.jna.ptr.PointerByReference;
 
 /**
  * Callback prototype to allocate and lock a picture buffer.
@@ -33,10 +34,10 @@ public interface libvlc_lock_callback_t extends Callback {
      * Whenever a new video frame needs to be decoded, the lock callback is invoked. Depending on
      * the video chroma, one or three pixel planes of adequate dimensions must be returned via the
      * second parameter. Those planes must be aligned on 32-bytes boundaries.
-     * 
+     *
      * @param opaque private pointer as passed to libvlc_video_set_callbacks() [IN]
      * @param planes start address of the pixel planes (LibVLC allocates the array of void pointers, this callback must initialize the array) [OUT]
      * @return a private pointer for the display and unlock callbacks to identify the picture buffers
      */
-    Pointer lock(Pointer opaque, Pointer planes);
+    Pointer lock(Pointer opaque, PointerByReference planes);
 }

--- a/src/main/java/uk/co/caprica/vlcj/binding/internal/libvlc_video_format_cb.java
+++ b/src/main/java/uk/co/caprica/vlcj/binding/internal/libvlc_video_format_cb.java
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with VLCJ.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  * Copyright 2009, 2010, 2011, 2012 Caprica Software Limited.
  */
 
@@ -35,7 +35,7 @@ public interface libvlc_video_format_cb extends Callback {
      * video filters (if any). It can opt to change any parameter as it needs. In that case, LibVLC
      * will attempt to convert the video format (rescaling and chroma conversion) but these
      * operations can be CPU intensive.
-     * 
+     *
      * @param opaque pointer to the private pointer passed to libvlc_video_set_callbacks() [IN/OUT]
      * @param chroma pointer to the 4 bytes video format identifier [IN/OUT]
      * @param width pointer to the pixel width [IN/OUT]
@@ -44,7 +44,7 @@ public interface libvlc_video_format_cb extends Callback {
      *            allocated by LibVLC) [OUT]
      * @param lines table of scanlines count for each plane [OUT]
      * @return the number of picture buffers allocated, 0 indicates failure
-     * 
+     *
      *         Note: For each pixels plane, the scanline pitch must be bigger than or equal to the
      *         number of bytes per pixel multiplied by the pixel width. Similarly, the number of
      *         scanlines must be bigger than of equal to the pixel height. Furthermore, we recommend
@@ -52,5 +52,5 @@ public interface libvlc_video_format_cb extends Callback {
      *         by various optimizations in the video decoders, video filters and/or video
      *         converters.
      */
-    int format(PointerByReference opaque, PointerByReference chroma, IntByReference width, IntByReference height, IntByReference pitches, IntByReference lines);
+    int format(PointerByReference opaque, PointerByReference chroma, IntByReference width, IntByReference height, PointerByReference pitchesRef, PointerByReference linesRef);
 }

--- a/src/main/java/uk/co/caprica/vlcj/component/DirectMediaPlayerComponent.java
+++ b/src/main/java/uk/co/caprica/vlcj/component/DirectMediaPlayerComponent.java
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with VLCJ.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  * Copyright 2009, 2010, 2011, 2012 Caprica Software Limited.
  */
 
@@ -23,6 +23,7 @@ import uk.co.caprica.vlcj.binding.internal.libvlc_media_t;
 import uk.co.caprica.vlcj.player.MediaPlayer;
 import uk.co.caprica.vlcj.player.MediaPlayerEventListener;
 import uk.co.caprica.vlcj.player.MediaPlayerFactory;
+import uk.co.caprica.vlcj.player.direct.BufferFormat;
 import uk.co.caprica.vlcj.player.direct.DirectMediaPlayer;
 import uk.co.caprica.vlcj.player.direct.RenderCallback;
 import uk.co.caprica.vlcj.player.direct.RenderCallbackAdapter;
@@ -40,13 +41,13 @@ import com.sun.jna.Memory;
  * <p>
  * An example: mediaPlayerComponent = new DirectMediaPlayerComponent() { protected String[]
  * onGetMediaPlayerFactoryArgs() { return new String[] {&quot;--no-video-title-show&quot;}; }
- * 
+ *
  * public void videoOutputAvailable(MediaPlayer mediaPlayer, boolean videoOutput) { }
- * 
+ *
  * public void error(MediaPlayer mediaPlayer) { }
- * 
+ *
  * public void finished(MediaPlayer mediaPlayer) { }
- * 
+ *
  * public void display(Memory nativeBuffer) { // Do something with the native video memory... } };
  * </pre>
  * When the media player component is no longer needed, it should be released by invoking the
@@ -67,12 +68,12 @@ public class DirectMediaPlayerComponent implements MediaPlayerEventListener, Ren
      * required.
      */
     protected static final String[] DEFAULT_FACTORY_ARGUMENTS = {
-        "--no-plugins-cache", 
-        "--no-video-title-show", 
-        "--no-snapshot-preview", 
-        "--quiet", 
-        "--quiet-synchro", 
-        "--intf", 
+        "--no-plugins-cache",
+        "--no-video-title-show",
+        "--no-snapshot-preview",
+        "--quiet",
+        "--quiet-synchro",
+        "--intf",
         "dummy"
     };
 
@@ -88,7 +89,7 @@ public class DirectMediaPlayerComponent implements MediaPlayerEventListener, Ren
 
     /**
      * Construct a media player component.
-     * 
+     *
      * @param format video format
      * @param width video width
      * @param height video height
@@ -106,7 +107,7 @@ public class DirectMediaPlayerComponent implements MediaPlayerEventListener, Ren
 
     /**
      * Get the media player factory reference.
-     * 
+     *
      * @return media player factory
      */
     public final MediaPlayerFactory getMediaPlayerFactory() {
@@ -117,7 +118,7 @@ public class DirectMediaPlayerComponent implements MediaPlayerEventListener, Ren
      * Get the direct media player reference.
      * <p>
      * An application uses this handle to control the media player, add listeners and so on.
-     * 
+     *
      * @return media player
      */
     public final DirectMediaPlayer getMediaPlayer() {
@@ -127,7 +128,7 @@ public class DirectMediaPlayerComponent implements MediaPlayerEventListener, Ren
     /**
      * Release the media player component and the associated native media player resources.
      * <p>
-     * The associated media player factory will <em>not</em> be released, the client 
+     * The associated media player factory will <em>not</em> be released, the client
      * application is responsible for releasing the factory at the appropriate time.
      */
     public final void release() {
@@ -141,7 +142,7 @@ public class DirectMediaPlayerComponent implements MediaPlayerEventListener, Ren
      * <p>
      * The default implementation will invoke the {@link #onGetMediaPlayerFactoryArgs()} template
      * method.
-     * 
+     *
      * @return media player factory
      */
     protected MediaPlayerFactory onGetMediaPlayerFactory() {
@@ -154,7 +155,7 @@ public class DirectMediaPlayerComponent implements MediaPlayerEventListener, Ren
      * <p>
      * If a sub-class overrides the {@link #onGetMediaPlayerFactory()} template method there is no
      * guarantee that {@link #onGetMediaPlayerFactoryArgs()} will be called.
-     * 
+     *
      * @return media player factory initialisation arguments
      */
     protected String[] onGetMediaPlayerFactoryArgs() {
@@ -169,7 +170,7 @@ public class DirectMediaPlayerComponent implements MediaPlayerEventListener, Ren
      * <p>
      * A sub-class may provide any implementation of {@link RenderCallback} - including
      * {@link RenderCallbackAdapter}.
-     * 
+     *
      * @return render callback implementation
      */
     protected RenderCallback onGetRenderCallback() {
@@ -181,7 +182,7 @@ public class DirectMediaPlayerComponent implements MediaPlayerEventListener, Ren
      */
     protected void onAfterConstruct() {
     }
-    
+
     /**
      * Template method invoked immediately prior to releasing the media player and media player
      * factory instances.
@@ -313,7 +314,7 @@ public class DirectMediaPlayerComponent implements MediaPlayerEventListener, Ren
     // === RenderCallback =======================================================
 
     @Override
-    public void display(DirectMediaPlayer mediaPlayer, Memory nativeBuffer) {
+    public void display(DirectMediaPlayer mediaPlayer, Memory[] nativeBuffers, BufferFormat bufferFormat) {
         // Default implementation does nothing, sub-classes should override this or
         // provide their own implementation of a RenderCallback
     }

--- a/src/main/java/uk/co/caprica/vlcj/player/MediaPlayerFactory.java
+++ b/src/main/java/uk/co/caprica/vlcj/player/MediaPlayerFactory.java
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with VLCJ.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  * Copyright 2009, 2010, 2011, 2012 Caprica Software Limited.
  */
 
@@ -37,6 +37,7 @@ import uk.co.caprica.vlcj.logger.Logger;
 import uk.co.caprica.vlcj.medialist.MediaList;
 import uk.co.caprica.vlcj.player.direct.DefaultDirectMediaPlayer;
 import uk.co.caprica.vlcj.player.direct.DirectMediaPlayer;
+import uk.co.caprica.vlcj.player.direct.BufferFormatCallback;
 import uk.co.caprica.vlcj.player.direct.RenderCallback;
 import uk.co.caprica.vlcj.player.discoverer.MediaDiscoverer;
 import uk.co.caprica.vlcj.player.embedded.DefaultEmbeddedMediaPlayer;
@@ -71,31 +72,31 @@ import uk.co.caprica.vlcj.version.LibVlcVersion;
  * of audio outputs, and the list of available audio and video filters.
  * <p>
  * Usage:
- * 
+ *
  * <pre>
  *   // Set some options for libvlc
  *   String[] libvlcArgs = {...add options here...};
- * 
+ *
  *   // Create a factory instance (once), you can keep a reference to this
  *   MediaPlayerFactory mediaPlayerFactory = new MediaPlayerFactory(libvlcArgs);
- *   
+ *
  *   // Create a full-screen strategy
  *   FullScreenStrategy fullScreenStrategy = new DefaultFullScreenStrategy(mainFrame);
- *   
+ *
  *   // Create a media player instance
  *   EmbeddedMediaPlayer mediaPlayer = mediaPlayerFactory.newEmbeddedMediaPlayer(fullScreenStrategy);
- * 
+ *
  *   // Do some interesting things with the media player, like setting a video surface...
- *   
+ *
  *   ...
- *   
+ *
  *   // Release the media player
  *   mediaPlayer.release();
- *   
+ *
  *   // Release the factory
  *   factory.release();
  * </pre>
- * 
+ *
  * You <em>must</em> make sure you keep a hard reference to the media player (and possibly other)
  * objects created by this factory. If you allow a media player object to go out of scope, then
  * unpredictable behaviour will occur (such as events no longer seeming to fire) even though the
@@ -116,7 +117,7 @@ public class MediaPlayerFactory {
         " 1. Make sure the plugins are installed in the \"<libvlc-path>/{2}\" directory, this should be the case with a normal vlc installation.\n" +
         " 2. Set the VLC_PLUGIN_PATH operating system environment variable to point to \"<plugins-path>\".\n\n" +
         "More information may be available in the log, specify -Dvlcj.log=DEBUG on the command-line when starting your application.\n\n";
-  
+
     /**
      * Native library interface.
      */
@@ -161,7 +162,7 @@ public class MediaPlayerFactory {
      * accepts a LibVlc instance that you obtain from the {@link LibVlcFactory}.
      * <p>
      * Most initialisation arguments may be gleaned by invoking <code>"vlc -H"</code>.
-     * 
+     *
      * @param libvlcArgs initialisation arguments to pass to libvlc
      */
     public MediaPlayerFactory(String... libvlcArgs) {
@@ -172,7 +173,7 @@ public class MediaPlayerFactory {
      * Create a new media player factory.
      * <p>
      * Use {@link LibVlcFactory} to get a reference to the native library.
-     * 
+     *
      * @param libvlc interface to the native library
      */
     public MediaPlayerFactory(LibVlc libvlc) {
@@ -183,7 +184,7 @@ public class MediaPlayerFactory {
      * Create a new media player factory.
      * <p>
      * Use {@link LibVlcFactory} to get a reference to the native library.
-     * 
+     *
      * @param libvlc interface to the native library
      * @param libvlcArgs initialisation arguments to pass to libvlc
      */
@@ -226,7 +227,7 @@ public class MediaPlayerFactory {
      * <p>
      * This is simply an alternate constructor for convenience, see
      * {@link #MediaPlayerFactory(String...)}.
-     * 
+     *
      * @param libvlcArgs initialisation arguments to pass to libvlc, may be empty but must not be <code>null</code>
      */
     public MediaPlayerFactory(List<String> libvlcArgs) {
@@ -240,7 +241,7 @@ public class MediaPlayerFactory {
      * <p>
      * This is simply an alternate constructor for convenience, see
      * {@link #MediaPlayerFactory(LibVlc, String...)}.
-     * 
+     *
      * @param libvlc interface to the native library
      * @param libvlcArgs initialisation arguments to pass to libvlc, may be empty but must not be <code>null</code>
      */
@@ -265,7 +266,7 @@ public class MediaPlayerFactory {
 
     /**
      * Set the application name.
-     * 
+     *
      * @param userAgent application name
      */
     public void setUserAgent(String userAgent) {
@@ -275,7 +276,7 @@ public class MediaPlayerFactory {
 
     /**
      * Set the application name.
-     * 
+     *
      * @param userAgent application name
      * @param httpUserAgent application name for HTTP
      */
@@ -289,7 +290,7 @@ public class MediaPlayerFactory {
      * <p>
      * Each audio output has zero or more audio devices, each device having it's own unique
      * identifier that can be used on a media player to set the select the required output device.
-     * 
+     *
      * @return collection of audio outputs
      */
     public List<AudioOutput> getAudioOutputs() {
@@ -309,7 +310,7 @@ public class MediaPlayerFactory {
 
     /**
      * Get the devices associated with an audio output.
-     * 
+     *
      * @param outputName output
      * @return collection of audio output devices
      */
@@ -343,9 +344,9 @@ public class MediaPlayerFactory {
 
     /**
      * Get the available audio filters.
-     * 
+     *
      * @return collection of audio filter descriptions
-     * 
+     *
      * @since libvlc 2.0.0
      */
     public List<ModuleDescription> getAudioFilters() {
@@ -363,9 +364,9 @@ public class MediaPlayerFactory {
 
     /**
      * Get the available video filters.
-     * 
+     *
      * @return collection of video filter descriptions
-     * 
+     *
      * @since libvlc 2.0.0
      */
     public List<ModuleDescription> getVideoFilters() {
@@ -383,7 +384,7 @@ public class MediaPlayerFactory {
 
     /**
      * Convert a collection of native module description structures.
-     * 
+     *
      * @param moduleDescriptions module descriptions
      * @return collection of module descriptions
      */
@@ -405,7 +406,7 @@ public class MediaPlayerFactory {
      * Full-screen will not be available, to enable full-screen support see
      * {@link #newEmbeddedMediaPlayer(FullScreenStrategy)}, or use an alternate mechanism to
      * manually set full-screen if needed.
-     * 
+     *
      * @return media player instance
      */
     public EmbeddedMediaPlayer newEmbeddedMediaPlayer() {
@@ -415,7 +416,7 @@ public class MediaPlayerFactory {
 
     /**
      * Create a new embedded media player.
-     * 
+     *
      * @param fullScreenStrategy full screen implementation, may be <code>null</code>
      * @return media player instance
      */
@@ -430,7 +431,7 @@ public class MediaPlayerFactory {
      * <p>
      * The pixel format used is "RV32" (a raw RGB format with padded alpha) and the pitch is
      * width*4.
-     * 
+     *
      * @param width width for the video
      * @param height height for the video
      * @param renderCallback call-back to receive the video frame data
@@ -443,7 +444,7 @@ public class MediaPlayerFactory {
 
     /**
      * Create a new direct video rendering media player.
-     * 
+     *
      * @param width width for the video
      * @param height height for the video
      * @param format pixel format (e.g. RV15, RV16, RV24, RV32, RGBA, YUYV)
@@ -457,12 +458,24 @@ public class MediaPlayerFactory {
     }
 
     /**
+     * Create a new direct video rendering media player.
+     *
+     * @param bufferFormatCallback call-back to set the desired buffer format
+     * @param renderCallback call-back to receive the video frame data
+     * @return media player instance
+     */
+    public DirectMediaPlayer newDirectMediaPlayer(BufferFormatCallback bufferFormatCallback, RenderCallback renderCallback) {
+        Logger.debug("newDirectMediaPlayer(formatCallback={},renderCallback={})", bufferFormatCallback, renderCallback);
+        return new DefaultDirectMediaPlayer(libvlc, instance, bufferFormatCallback, renderCallback);
+    }
+
+    /**
      * Create a new head-less media player.
      * <p>
      * The head-less player is intended for audio media players or streaming server media players
      * and may spawn a native video player window unless you set proper media options when playing
      * media.
-     * 
+     *
      * @return media player instance
      */
     public HeadlessMediaPlayer newHeadlessMediaPlayer() {
@@ -472,7 +485,7 @@ public class MediaPlayerFactory {
 
     /**
      * Create a new play-list media player.
-     * 
+     *
      * @return media player instance
      */
     public MediaListPlayer newMediaListPlayer() {
@@ -484,7 +497,7 @@ public class MediaPlayerFactory {
 
     /**
      * Create a new video surface for a Canvas.
-     * 
+     *
      * @param canvas canvas
      * @return video surface
      */
@@ -510,7 +523,7 @@ public class MediaPlayerFactory {
 
     /**
      * Create a new video surface for a native component id.
-     * 
+     *
      * @param componentId native component id
      * @return video surface
      */
@@ -538,7 +551,7 @@ public class MediaPlayerFactory {
 
     /**
      * Create a new media list for a play-list media player.
-     * 
+     *
      * @return media list instance
      */
     public MediaList newMediaList() {
@@ -553,7 +566,7 @@ public class MediaPlayerFactory {
      * <p>
      * Note that requesting meta data may cause one or more HTTP connections to
      * be made to external web-sites to attempt download of album art.
-     * 
+     *
      * @param mediaPath path to the local media
      * @param parse <code>true</code> if the media should be parsed immediately</code>; otherwise <code>false</code>
      * @return media meta data, or <code>null</code> if the media could not be located
@@ -584,7 +597,7 @@ public class MediaPlayerFactory {
      * Create a new native log component.
      * <p>
      * <strong>The native log requires vlc 2.1.0 or later.</strong>
-     * 
+     *
      * @return native log component, or <code>null</code> if the native log is not available
      */
     public NativeLog newLog() {
@@ -604,7 +617,7 @@ public class MediaPlayerFactory {
      * Create a new native media service discoverer.
      * <p>
      * Not all media discoveres are supported on all platforms.
-     * 
+     *
      * @param name name of the required service discoverer, e.g. "audio", "video".
      * @return native media discoverer component
      */
@@ -612,19 +625,19 @@ public class MediaPlayerFactory {
         Logger.debug("newMediaDiscoverer(name={})", name);
         return new MediaDiscoverer(libvlc, instance, name);
     }
-    
+
     /**
      * Create a new native audio media service discoverer.
      * <p>
      * This method is simply a convenient wrapper around {@link #newMediaDiscoverer(String)}.
-     * 
+     *
      * @return native media discoverer component
      */
     public MediaDiscoverer newAudioMediaDiscoverer() {
         Logger.debug("newAudioMediaDiscoverer()");
         return newMediaDiscoverer("audio");
     }
-    
+
     /**
      * Create a new native video media service discoverer.
      * <p>
@@ -634,14 +647,14 @@ public class MediaPlayerFactory {
      * This method is simply a convenient wrapper around {@link #newMediaDiscoverer(String)}.
      * <p>
      * The video discoverer may not be available on all platforms.
-     * 
+     *
      * @return native media discoverer component
      */
     public MediaDiscoverer newVideoMediaDiscoverer() {
         Logger.debug("newVideoMediaDiscoverer()");
         return newMediaDiscoverer("video");
     }
-    
+
     // === Clock ================================================================
 
     /**
@@ -649,7 +662,7 @@ public class MediaPlayerFactory {
      * <p>
      * The time is not meaningful in the sense of what time is it, rather it is a monotonic clock
      * with an arbitrary starting value.
-     * 
+     *
      * @return current clock time value, in microseconds
      */
     public long clock() {
@@ -661,7 +674,7 @@ public class MediaPlayerFactory {
 
     /**
      * Create a new media manager.
-     * 
+     *
      * @return media manager instance
      */
     public MediaManager newMediaManager() {
@@ -673,7 +686,7 @@ public class MediaPlayerFactory {
 
     /**
      * Get the libvlc version.
-     * 
+     *
      * @return native library version
      */
     public String version() {
@@ -683,7 +696,7 @@ public class MediaPlayerFactory {
 
     /**
      * Get the compiler used to build libvlc.
-     * 
+     *
      * @return compiler
      */
     public String compiler() {
@@ -693,7 +706,7 @@ public class MediaPlayerFactory {
 
     /**
      * Get the source code change-set id used to build libvlc.
-     * 
+     *
      * @return change-set
      */
     public String changeset() {

--- a/src/main/java/uk/co/caprica/vlcj/player/direct/BufferFormat.java
+++ b/src/main/java/uk/co/caprica/vlcj/player/direct/BufferFormat.java
@@ -1,0 +1,119 @@
+package uk.co.caprica.vlcj.player.direct;
+
+import java.util.Arrays;
+
+/**
+ * Specifies the format of the buffers used by the DirectMediaPlayer.<p>
+ * The buffer will contain data of the given width and height in the format
+ * specified by the chroma parameter.  A buffer can consist of multiple planes depending
+ * on the format of the data.  For each plane the pitch and height in lines must be
+ * supplied.<p>
+ * For example, RV32 format has only one plane.  Its pitch is width * 4, and its number of lines
+ * is the same as the height of the buffer.<p>
+ */
+public class BufferFormat {
+    private final String chroma;
+    private final int width;
+    private final int height;
+    private final int[] pitches;
+    private final int[] lines;
+
+    /**
+     * Constructs a new BufferFormat instance with the given parameters.
+     *
+     * @param chroma a VLC buffer type, must be exactly 4 characters and cannot contain non-ASCII characters
+     * @param width the width of the buffer, must be > 0
+     * @param height the height of the buffer, must be > 0
+     * @param pitches the pitch of each plane that this buffer consists of (usually a multiple of width)
+     * @param lines the number of lines of each plane that this buffer consists of (usually same as height)
+     */
+    public BufferFormat(String chroma, int width, int height, int[] pitches, int[] lines) {
+        if(chroma == null || chroma.length() != 4) {
+            throw new IllegalArgumentException("Parameter 'chroma' cannot be null and must be exactly 4 characters: " + chroma);
+        }
+        if(pitches == null || pitches.length == 0) {
+            throw new IllegalArgumentException("Parameter 'pitches' cannot be null or zero-length");
+        }
+        if(lines == null || lines.length == 0) {
+            throw new IllegalArgumentException("Parameter 'lines' cannot be null or zero-length");
+        }
+        if(width <= 0) {
+            throw new IllegalArgumentException("Parameter 'width' cannot be 0 or negative: " + width);
+        }
+        if(height <= 0) {
+            throw new IllegalArgumentException("Parameter 'height' cannot be 0 or negative: " + height);
+        }
+        if(pitches.length != lines.length) {
+            throw new IllegalArgumentException("Parameter 'pitches' and 'lines' must be of same length");
+        }
+
+        for(int i = 0; i < pitches.length; i++) {
+            if(pitches[i] <= 0) {
+                throw new IllegalArgumentException("Parameter 'pitches' cannot elements that are 0 or negative: " + Arrays.toString(pitches));
+            }
+            if(lines[i] <= 0) {
+                throw new IllegalArgumentException("Parameter 'lines' cannot elements that are 0 or negative: " + Arrays.toString(lines));
+            }
+        }
+
+        this.chroma = chroma;
+        this.width = width;
+        this.height = height;
+        this.pitches = pitches;
+        this.lines = lines;
+    }
+
+    /**
+     * Returns the pixel format of the buffer.
+     *
+     * @return the pixel format of the buffer
+     */
+    public String getChroma() {
+        return chroma;
+    }
+
+    /**
+     * Returns the width of the buffer.
+     *
+     * @return the width of the buffer
+     */
+    public int getWidth() {
+        return width;
+    }
+
+    /**
+     * Returns the height of the buffer.
+     *
+     * @return the height of the buffer
+     */
+    public int getHeight() {
+        return height;
+    }
+
+    /**
+     * Returns the pitch of each plane of the buffer.
+     *
+     * @return the pitch of each plane of the buffer
+     */
+    public int[] getPitches() {
+        return pitches;
+    }
+
+    /**
+     * Returns the number of lines of each plane of the buffer.
+     *
+     * @return the number of lines of each plane of the buffer
+     */
+    public int[] getLines() {
+        return lines;
+    }
+
+    /**
+     * Returns the number of planes in the buffer.
+     *
+     * @return the number of planes in the buffer
+     */
+    public int getPlaneCount() {
+        return pitches.length;
+    }
+}

--- a/src/main/java/uk/co/caprica/vlcj/player/direct/BufferFormatCallback.java
+++ b/src/main/java/uk/co/caprica/vlcj/player/direct/BufferFormatCallback.java
@@ -1,0 +1,16 @@
+package uk.co.caprica.vlcj.player.direct;
+
+/**
+ * Gets called by DirectMediaPlayer when the format of the video changes.
+ */
+public interface BufferFormatCallback {
+
+    /**
+     * Returns a BufferFormat instance specifying how DirectMediaPlayer should structure its buffers.
+     *
+     * @param originalWidth the width of the video
+     * @param originalHeight the height of the video
+     * @return a BufferFormat instance
+     */
+    BufferFormat getBufferFormat(int originalWidth, int originalHeight);
+}

--- a/src/main/java/uk/co/caprica/vlcj/player/direct/RV32BufferFormat.java
+++ b/src/main/java/uk/co/caprica/vlcj/player/direct/RV32BufferFormat.java
@@ -1,0 +1,17 @@
+package uk.co.caprica.vlcj.player.direct;
+
+/**
+ * Convience class to create the RV32 buffer format.
+ */
+public class RV32BufferFormat extends BufferFormat {
+
+    /**
+     * Creates a RV32 BufferFormat with the given width and height.
+     *
+     * @param width width of the buffer
+     * @param height height of the buffer
+     */
+    public RV32BufferFormat(int width, int height) {
+        super("RV32", width, height, new int[] {width * 4}, new int[] {height});
+    }
+}

--- a/src/main/java/uk/co/caprica/vlcj/player/direct/RenderCallback.java
+++ b/src/main/java/uk/co/caprica/vlcj/player/direct/RenderCallback.java
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with VLCJ.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  * Copyright 2009, 2010, 2011, 2012 Caprica Software Limited.
  */
 
@@ -31,9 +31,9 @@ public interface RenderCallback {
 
     /**
      * Call-back when ready to display a video frame.
-     * 
+     *
      * @param mediaPlayer media player to which the event relates
      * @param nativeBuffer video data for one frame
      */
-    public void display(DirectMediaPlayer mediaPlayer, Memory nativeBuffer);
+    public void display(DirectMediaPlayer mediaPlayer, Memory[] nativeBuffers, BufferFormat bufferFormat);
 }

--- a/src/main/java/uk/co/caprica/vlcj/player/direct/RenderCallbackAdapter.java
+++ b/src/main/java/uk/co/caprica/vlcj/player/direct/RenderCallbackAdapter.java
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with VLCJ.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  * Copyright 2009, 2010, 2011, 2012 Caprica Software Limited.
  */
 
@@ -39,7 +39,7 @@ public abstract class RenderCallbackAdapter implements RenderCallback {
 
     /**
      * Create a new render call-back.
-     * 
+     *
      * @param rgbBuffer video data buffer
      */
     public RenderCallbackAdapter(int[] rgbBuffer) {
@@ -47,14 +47,14 @@ public abstract class RenderCallbackAdapter implements RenderCallback {
     }
 
     @Override
-    public final void display(DirectMediaPlayer mediaPlayer, Memory nativeBuffer) {
-        nativeBuffer.read(0, rgbBuffer, 0, rgbBuffer.length);
+    public final void display(DirectMediaPlayer mediaPlayer, Memory[] nativeBuffer, BufferFormat bufferFormat) {
+        nativeBuffer[0].read(0, rgbBuffer, 0, rgbBuffer.length);
         onDisplay(rgbBuffer);
     }
 
     /**
      * Get the video data buffer.
-     * 
+     *
      * @return video buffer
      */
     public int[] rgbBuffer() {
@@ -63,7 +63,7 @@ public abstract class RenderCallbackAdapter implements RenderCallback {
 
     /**
      * Template method invoked when a new frame of video data is ready.
-     * 
+     *
      * @param rgbBuffer video data buffer
      */
     protected abstract void onDisplay(int[] rgbBuffer);


### PR DESCRIPTION
I've added a new constructor to DirectMediaPlayer and made the old constructor call the new one since the new one is more general.

I introduced a BufferFormat class for configuring the format of the buffers in the newly introduced call back interface BufferFormatCallback.  I also understand now how VLC handles multiple "buffers" -- they are planes actually for formats that have several buffers (like YV42 where the buffers are not all the same size for each color component).

I've implemented this support as well, so multiple buffers can be allocated if required.

I was unable to run your tests -- I donot know if I broke anything, but probably I guess.  Let me know what you think.
