### PR TITLE
DirectMediaPlayer with format callback support (updated)

### DIFF
--- a/src/main/java/uk/co/caprica/vlcj/component/DirectMediaPlayerComponent.java
+++ b/src/main/java/uk/co/caprica/vlcj/component/DirectMediaPlayerComponent.java
@@ -23,6 +23,7 @@ import uk.co.caprica.vlcj.binding.internal.libvlc_media_t;
 import uk.co.caprica.vlcj.player.MediaPlayer;
 import uk.co.caprica.vlcj.player.MediaPlayerEventListener;
 import uk.co.caprica.vlcj.player.MediaPlayerFactory;
+import uk.co.caprica.vlcj.player.direct.BufferFormat;
 import uk.co.caprica.vlcj.player.direct.DirectMediaPlayer;
 import uk.co.caprica.vlcj.player.direct.RenderCallback;
 import uk.co.caprica.vlcj.player.direct.RenderCallbackAdapter;
@@ -313,7 +314,7 @@ public class DirectMediaPlayerComponent implements MediaPlayerEventListener, Ren
     // === RenderCallback =======================================================
 
     @Override
-    public void display(DirectMediaPlayer mediaPlayer, Memory nativeBuffer) {
+    public void display(DirectMediaPlayer mediaPlayer, Memory[] nativeBuffers, BufferFormat bufferFormat) {
         // Default implementation does nothing, sub-classes should override this or
         // provide their own implementation of a RenderCallback
     }

--- a/src/main/java/uk/co/caprica/vlcj/player/MediaPlayerFactory.java
+++ b/src/main/java/uk/co/caprica/vlcj/player/MediaPlayerFactory.java
@@ -35,6 +35,7 @@ import uk.co.caprica.vlcj.binding.internal.libvlc_module_description_t;
 import uk.co.caprica.vlcj.log.NativeLog;
 import uk.co.caprica.vlcj.logger.Logger;
 import uk.co.caprica.vlcj.medialist.MediaList;
+import uk.co.caprica.vlcj.player.direct.BufferFormatCallback;
 import uk.co.caprica.vlcj.player.direct.DefaultDirectMediaPlayer;
 import uk.co.caprica.vlcj.player.direct.DirectMediaPlayer;
 import uk.co.caprica.vlcj.player.direct.RenderCallback;
@@ -456,6 +457,18 @@ public class MediaPlayerFactory {
         return new DefaultDirectMediaPlayer(libvlc, instance, format, width, height, pitch, renderCallback);
     }
 
+    /**
+     * Create a new direct video rendering media player.
+     *
+     * @param bufferFormatCallback call-back to set the desired buffer format
+     * @param renderCallback call-back to receive the video frame data
+     * @return media player instance
+     */
+    public DirectMediaPlayer newDirectMediaPlayer(BufferFormatCallback bufferFormatCallback, RenderCallback renderCallback) {
+        Logger.debug("newDirectMediaPlayer(formatCallback={},renderCallback={})", bufferFormatCallback, renderCallback);
+        return new DefaultDirectMediaPlayer(libvlc, instance, bufferFormatCallback, renderCallback);
+    }
+    
     /**
      * Create a new head-less media player.
      * <p>

--- a/src/main/java/uk/co/caprica/vlcj/player/direct/BufferFormat.java
+++ b/src/main/java/uk/co/caprica/vlcj/player/direct/BufferFormat.java
@@ -1,0 +1,128 @@
+package uk.co.caprica.vlcj.player.direct;
+
+import java.util.Arrays;
+
+/**
+ * Specifies the format of the buffers used by the DirectMediaPlayer.
+ * <p>
+ * The buffer will contain data of the given width and height in the format specified by the chroma
+ * parameter. A buffer can consist of multiple planes depending on the format of the data. For each
+ * plane the pitch and height in lines must be supplied.
+ * <p>
+ * For example, RV32 format has only one plane. Its pitch is width * 4, and its number of lines is
+ * the same as the height of the buffer.
+ * <p>
+ */
+public class BufferFormat {
+    private final String chroma;
+
+    private final int width;
+
+    private final int height;
+
+    private final int[] pitches;
+
+    private final int[] lines;
+
+    /**
+     * Constructs a new BufferFormat instance with the given parameters.
+     * 
+     * @param chroma a VLC buffer type, must be exactly 4 characters and cannot contain non-ASCII
+     *            characters
+     * @param width the width of the buffer, must be > 0
+     * @param height the height of the buffer, must be > 0
+     * @param pitches the pitch of each plane that this buffer consists of (usually a multiple of
+     *            width)
+     * @param lines the number of lines of each plane that this buffer consists of (usually same as
+     *            height)
+     */
+    public BufferFormat(String chroma, int width, int height, int[] pitches, int[] lines) {
+        if(chroma == null || chroma.length() != 4) {
+            throw new IllegalArgumentException("Parameter 'chroma' cannot be null and must be exactly 4 characters: " + chroma);
+        }
+        if(pitches == null || pitches.length == 0) {
+            throw new IllegalArgumentException("Parameter 'pitches' cannot be null or zero-length");
+        }
+        if(lines == null || lines.length == 0) {
+            throw new IllegalArgumentException("Parameter 'lines' cannot be null or zero-length");
+        }
+        if(width <= 0) {
+            throw new IllegalArgumentException("Parameter 'width' cannot be 0 or negative: " + width);
+        }
+        if(height <= 0) {
+            throw new IllegalArgumentException("Parameter 'height' cannot be 0 or negative: " + height);
+        }
+        if(pitches.length != lines.length) {
+            throw new IllegalArgumentException("Parameter 'pitches' and 'lines' must be of same length");
+        }
+
+        for(int i = 0; i < pitches.length; i ++ ) {
+            if(pitches[i] <= 0) {
+                throw new IllegalArgumentException("Parameter 'pitches' cannot elements that are 0 or negative: " + Arrays.toString(pitches));
+            }
+            if(lines[i] <= 0) {
+                throw new IllegalArgumentException("Parameter 'lines' cannot elements that are 0 or negative: " + Arrays.toString(lines));
+            }
+        }
+
+        this.chroma = chroma;
+        this.width = width;
+        this.height = height;
+        this.pitches = pitches;
+        this.lines = lines;
+    }
+
+    /**
+     * Returns the pixel format of the buffer.
+     * 
+     * @return the pixel format of the buffer
+     */
+    public String getChroma() {
+        return chroma;
+    }
+
+    /**
+     * Returns the width of the buffer.
+     * 
+     * @return the width of the buffer
+     */
+    public int getWidth() {
+        return width;
+    }
+
+    /**
+     * Returns the height of the buffer.
+     * 
+     * @return the height of the buffer
+     */
+    public int getHeight() {
+        return height;
+    }
+
+    /**
+     * Returns the pitch of each plane of the buffer.
+     * 
+     * @return the pitch of each plane of the buffer
+     */
+    public int[] getPitches() {
+        return pitches;
+    }
+
+    /**
+     * Returns the number of lines of each plane of the buffer.
+     * 
+     * @return the number of lines of each plane of the buffer
+     */
+    public int[] getLines() {
+        return lines;
+    }
+
+    /**
+     * Returns the number of planes in the buffer.
+     * 
+     * @return the number of planes in the buffer
+     */
+    public int getPlaneCount() {
+        return pitches.length;
+    }
+}

--- a/src/main/java/uk/co/caprica/vlcj/player/direct/BufferFormatCallback.java
+++ b/src/main/java/uk/co/caprica/vlcj/player/direct/BufferFormatCallback.java
@@ -1,0 +1,17 @@
+package uk.co.caprica.vlcj.player.direct;
+
+/**
+ * Gets called by DirectMediaPlayer when the format of the video changes.
+ */
+public interface BufferFormatCallback {
+
+    /**
+     * Returns a BufferFormat instance specifying how DirectMediaPlayer should structure its
+     * buffers.
+     * 
+     * @param originalWidth the width of the video
+     * @param originalHeight the height of the video
+     * @return a BufferFormat instance
+     */
+    BufferFormat getBufferFormat(int originalWidth, int originalHeight);
+}

--- a/src/main/java/uk/co/caprica/vlcj/player/direct/DefaultDirectMediaPlayer.java
+++ b/src/main/java/uk/co/caprica/vlcj/player/direct/DefaultDirectMediaPlayer.java
@@ -26,11 +26,14 @@ import uk.co.caprica.vlcj.binding.internal.libvlc_display_callback_t;
 import uk.co.caprica.vlcj.binding.internal.libvlc_instance_t;
 import uk.co.caprica.vlcj.binding.internal.libvlc_lock_callback_t;
 import uk.co.caprica.vlcj.binding.internal.libvlc_unlock_callback_t;
+import uk.co.caprica.vlcj.binding.internal.libvlc_video_cleanup_cb;
+import uk.co.caprica.vlcj.binding.internal.libvlc_video_format_cb;
 import uk.co.caprica.vlcj.logger.Logger;
 import uk.co.caprica.vlcj.player.DefaultMediaPlayer;
 
 import com.sun.jna.Memory;
 import com.sun.jna.Pointer;
+import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.PointerByReference;
 
 /**
@@ -57,34 +60,9 @@ public class DefaultDirectMediaPlayer extends DefaultMediaPlayer implements Dire
     private final Semaphore semaphore = new Semaphore(1);
 
     /**
-     * Video buffer pixel format.
-     */
-    private final String format;
-
-    /**
-     * Video buffer width.
-     */
-    private final int width;
-
-    /**
-     * Video buffer height.
-     */
-    private final int height;
-
-    /**
-     * Video buffer pitch (or "stride").
-     */
-    private final int pitch;
-
-    /**
      * Component to call-back for each video frame.
      */
     private final RenderCallback renderCallback;
-
-    /**
-     * Native memory buffer.
-     */
-    private final Memory nativeBuffer;
 
     /**
      * Lock call-back.
@@ -111,7 +89,34 @@ public class DefaultDirectMediaPlayer extends DefaultMediaPlayer implements Dire
     private final libvlc_display_callback_t display;
 
     /**
-     * Create a new media player.
+     * Setup call-back.
+     * <p>
+     * A hard reference to the call-back must be kept otherwise the call-back will get garbage
+     * collected and cause a native crash.
+     */
+    private final libvlc_video_format_cb setup;
+
+    /**
+     * Cleanup call-back.
+     * <p>
+     * A hard reference to the call-back must be kept otherwise the call-back will get garbage
+     * collected and cause a native crash.
+     */
+    private final libvlc_video_cleanup_cb cleanup;
+
+    /**
+     * Format of the native buffers.
+     */
+    private BufferFormat bufferFormat;
+
+    /**
+     * Native memory buffers, one for each plane.
+     */
+    private Memory[] nativeBuffers;
+
+    /**
+     * Create a new media player. Note: this constructor does not support formats that require
+     * multiple planes (buffers)
      * 
      * @param libvlc native library interface
      * @param instance libvlc instance
@@ -121,30 +126,46 @@ public class DefaultDirectMediaPlayer extends DefaultMediaPlayer implements Dire
      * @param pitch pitch, also known as stride
      * @param renderCallback call-back to receive the video frame data
      */
-    public DefaultDirectMediaPlayer(LibVlc libvlc, libvlc_instance_t instance, String format, int width, int height, int pitch, RenderCallback renderCallback) {
+    public DefaultDirectMediaPlayer(LibVlc libvlc, libvlc_instance_t instance, final String format, final int width, final int height, final int pitch, RenderCallback renderCallback) {
+        this(libvlc, instance, new BufferFormatCallback() {
+            @Override
+            public BufferFormat getBufferFormat(int originalWidth, int originalHeight) {
+                return new BufferFormat(format, width, height, new int[] {pitch}, new int[] {height});
+            }
+        }, renderCallback);
+    }
+
+    /**
+     * Create a new media player.
+     * 
+     * @param libvlc native library interface
+     * @param instance libvlc instance
+     * @param bufferFormatCallback call-back to set the desired buffer format
+     * @param renderCallback call-back to receive the video frame data
+     */
+    public DefaultDirectMediaPlayer(LibVlc libvlc, libvlc_instance_t instance, final BufferFormatCallback bufferFormatCallback, RenderCallback renderCallback) {
         super(libvlc, instance);
 
-        this.format = format;
-        this.width = width;
-        this.height = height;
-        this.pitch = pitch;
         this.renderCallback = renderCallback;
-
-        // Memory must be aligned correctly (on a 32-byte boundary) for the libvlc
-        // API functions (extra bytes are allocated to allow for enough memory if
-        // the alignment needs to be changed)
-        this.nativeBuffer = new Memory(width * height * 4 + 32).align(32);
 
         this.lock = new libvlc_lock_callback_t() {
             @Override
-            public Pointer lock(Pointer opaque, PointerByReference plane) {
+            public Pointer lock(Pointer opaque, PointerByReference planesRef) {
                 Logger.trace("lock");
                 // Acquire the single permit from the semaphore to ensure that the
                 // memory buffer is not trashed while display() is invoked
                 Logger.trace("acquire");
                 semaphore.acquireUninterruptibly();
                 Logger.trace("acquired");
-                plane.setValue(nativeBuffer);
+
+                Pointer[] planes = new Pointer[bufferFormat.getPlaneCount()];
+
+                for(int i = 0; i < bufferFormat.getPlaneCount(); i ++ ) {
+                    planes[i] = nativeBuffers[i];
+                }
+
+                planesRef.getPointer().write(0, planes, 0, planes.length);
+
                 Logger.trace("lock finished");
                 return null;
             }
@@ -167,50 +188,64 @@ public class DefaultDirectMediaPlayer extends DefaultMediaPlayer implements Dire
             public void display(Pointer opaque, Pointer picture) {
                 Logger.trace("display");
                 // Invoke the call-back
-                DefaultDirectMediaPlayer.this.renderCallback.display(DefaultDirectMediaPlayer.this, nativeBuffer);
+                DefaultDirectMediaPlayer.this.renderCallback.display(DefaultDirectMediaPlayer.this, nativeBuffers, bufferFormat);
                 Logger.trace("display finished");
             }
         };
 
-        // Set the desired video buffer format
-        libvlc.libvlc_video_set_format(mediaPlayerInstance(), format, width, height, pitch);
+        this.setup = new libvlc_video_format_cb() {
+            @Override
+            public int format(PointerByReference opaque, PointerByReference chroma, IntByReference width, IntByReference height, PointerByReference pitchesRef, PointerByReference linesRef) {
+                bufferFormat = bufferFormatCallback.getBufferFormat(width.getValue(), height.getValue());
+
+                if(bufferFormat == null) {
+                    throw new IllegalStateException("BufferFormat cannot be null");
+                }
+
+                byte[] chromaBytes = bufferFormat.getChroma().getBytes();
+
+                chroma.getPointer().write(0, chromaBytes, 0, chromaBytes.length > 4 ? 4 : chromaBytes.length);
+                width.setValue(bufferFormat.getWidth());
+                height.setValue(bufferFormat.getHeight());
+
+                int[] pitches = bufferFormat.getPitches();
+                int[] lines = bufferFormat.getLines();
+                nativeBuffers = new Memory[pitches.length];
+
+                for(int i = 0; i < pitches.length; i ++ ) {
+                    pitchesRef.getPointer().setInt(i * 4, pitches[i]);
+                    linesRef.getPointer().setInt(i * 4, lines[i]);
+
+                    // Memory must be aligned correctly (on a 32-byte boundary) for the libvlc
+                    // API functions (extra bytes are allocated to allow for enough memory if
+                    // the alignment needs to be changed)
+                    nativeBuffers[i] = new Memory(pitches[i] * lines[i] + 32).align(32);
+                }
+
+                return pitches.length;
+            }
+        };
+
+        this.cleanup = new libvlc_video_cleanup_cb() {
+            @Override
+            public void cleanup(Pointer opaque) {
+                if(nativeBuffers != null) {
+                    nativeBuffers = null;
+                }
+            }
+        };
+
         // Install the video callbacks
         libvlc.libvlc_video_set_callbacks(mediaPlayerInstance(), lock, unlock, display, null);
+        libvlc.libvlc_video_set_format_callbacks(mediaPlayerInstance(), setup, cleanup);
     }
 
     /**
-     * Get the buffer format.
+     * Get the current buffer format.
      * 
-     * @return format
+     * @return the current buffer format
      */
-    public String format() {
-        return format;
-    }
-
-    /**
-     * Get the buffer width.
-     * 
-     * @return width
-     */
-    public int width() {
-        return width;
-    }
-
-    /**
-     * Get the buffer height.
-     * 
-     * @return height
-     */
-    public int height() {
-        return height;
-    }
-
-    /**
-     * Get the buffer pitch.
-     * 
-     * @return pitch
-     */
-    public int pitch() {
-        return pitch;
+    public BufferFormat getBufferFormat() {
+        return bufferFormat;
     }
 }

--- a/src/main/java/uk/co/caprica/vlcj/player/direct/RenderCallback.java
+++ b/src/main/java/uk/co/caprica/vlcj/player/direct/RenderCallback.java
@@ -34,6 +34,7 @@ public interface RenderCallback {
      * 
      * @param mediaPlayer media player to which the event relates
      * @param nativeBuffer video data for one frame
+     * @param bufferFormat information about the format of the buffer used
      */
-    public void display(DirectMediaPlayer mediaPlayer, Memory nativeBuffer);
+    public void display(DirectMediaPlayer mediaPlayer, Memory[] nativeBuffers, BufferFormat bufferFormat);
 }

--- a/src/main/java/uk/co/caprica/vlcj/player/direct/RenderCallbackAdapter.java
+++ b/src/main/java/uk/co/caprica/vlcj/player/direct/RenderCallbackAdapter.java
@@ -47,8 +47,8 @@ public abstract class RenderCallbackAdapter implements RenderCallback {
     }
 
     @Override
-    public final void display(DirectMediaPlayer mediaPlayer, Memory nativeBuffer) {
-        nativeBuffer.read(0, rgbBuffer, 0, rgbBuffer.length);
+    public final void display(DirectMediaPlayer mediaPlayer, Memory[] nativeBuffer, BufferFormat bufferFormat) {
+        nativeBuffer[0].read(0, rgbBuffer, 0, rgbBuffer.length);
         onDisplay(rgbBuffer);
     }
 


### PR DESCRIPTION
Update: I removed all the white space changes and formatted the code I added.  Also added some more missing javadoc.

I've added a new constructor to DirectMediaPlayer and made the old constructor call the new one since the new one is more general.

I introduced a BufferFormat class for configuring the format of the buffers in the newly introduced call back interface BufferFormatCallback. I also understand now how VLC handles multiple "buffers" -- they are planes actually for formats that have several buffers (like YV42 where the buffers are not all the same size for each color component).

I've implemented this support as well, so multiple buffers can be allocated if required.

I was unable to run your tests -- I donot know if I broke anything, but probably I guess. Let me know what you think.
