### PR TITLE
Add implementation of WindowPlayer for mac.

### DIFF
--- a/src/main/java/uk/co/caprica/vlcj/component/StandaloneMediaPlayerWindow.java
+++ b/src/main/java/uk/co/caprica/vlcj/component/StandaloneMediaPlayerWindow.java
@@ -1,0 +1,639 @@
+/*
+ * This file is part of VLCJ.
+ *
+ * VLCJ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VLCJ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VLCJ.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2009-2016 Caprica Software Limited.
+ */
+
+package uk.co.caprica.vlcj.component;
+
+import java.awt.Cursor;
+import java.awt.Image;
+import java.awt.Point;
+import java.awt.Toolkit;
+import java.awt.Window;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.awt.event.MouseMotionListener;
+import java.awt.event.MouseWheelEvent;
+import java.awt.event.MouseWheelListener;
+import java.awt.image.BufferedImage;
+import java.util.Arrays;
+
+import javax.swing.JWindow;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import uk.co.caprica.vlcj.binding.internal.libvlc_media_t;
+import uk.co.caprica.vlcj.player.MediaPlayer;
+import uk.co.caprica.vlcj.player.MediaPlayerEventListener;
+import uk.co.caprica.vlcj.player.MediaPlayerFactory;
+import uk.co.caprica.vlcj.player.embedded.FullScreenStrategy;
+import uk.co.caprica.vlcj.player.embedded.WindowedMediaPlayer;
+import uk.co.caprica.vlcj.player.embedded.videosurface.WindowVideoSurface;
+import uk.co.caprica.vlcj.runtime.RuntimeUtil;
+
+/**
+ * Encapsulation of an window media player.
+ * <p>
+ * This component encapsulates a media player and an associated video surface suitable for mac.
+ * You need to initialize the AWT window object before using this class.
+ * <p>
+ * Most implementation details, like creating a factory and connecting the various objects together,
+ * are encapsulated.
+ * <p>
+ * The default implementation will work out-of-the-box, but there are various template methods
+ * available to sub-classes to tailor the behaviour of the component.
+ * <p>
+ * This class implements the most the most common use-case for an embedded media player and is
+ * intended to enable a developer to get quickly started with the vlcj framework. More advanced
+ * applications are free to directly use the {@link MediaPlayerFactory}, if required, as has always
+ * been the case.
+ * <p>
+ * This component also implements the various media player listener interfaces, consequently an
+ * implementation sub-class can simply override those listener methods to handle events.
+ * <p>
+ * Applications can get a handle to the underlying media player object by invoking
+ * {@link #getMediaPlayer()}.
+ * <p>
+ * To use, simply create an instance of AWT window and pass to constructor of this class.
+ * <p>
+ * For example, make a window that meets your own needs, and use it to build the player window.
+ *
+ * <pre>
+ * Window window = new Window(null);
+ * window.setBounds(200, 200, 800, 480);
+ * window.setVisible(true);
+ * StandaloneMediaPlayerWindow playerWindow = new StandaloneMediaPlayerWindow(window);
+ * playerWindow.getMediaPlayer().playMedia(mrl); // &lt;--- 2
+ * </pre>
+ *
+ * An example of a sub-class to tailor behaviours and override event handlers:
+ *
+ * <pre>
+ * playerWindow = new StandaloneMediaPlayerWindow(window) {
+ *     protected String[] onGetMediaPlayerFactoryArgs() {
+ *         return new String[] {&quot;--no-video-title-show&quot;};
+ *     }
+ *
+ *     protected FullScreenStrategy onGetFullScreenStrategy() {
+ *         return new XFullScreenStrategy(frame);
+ *     }
+ *
+ *     public void videoOutputAvailable(MediaPlayer mediaPlayer, boolean videoOutput) {
+ *     }
+ *
+ *     public void error(MediaPlayer mediaPlayer) {
+ *     }
+ *
+ *     public void finished(MediaPlayer mediaPlayer) {
+ *     }
+ * };
+ * </pre>
+ * Note: Key and mouse events may not work properly with this implementation.
+ * <p>
+ * When the media player component is no longer needed, it should be released by invoking the
+ * {@link #release()} method.
+ * <p>
+ * Since the media player factory associated by this component may be created by this component
+ * itself or may be shared with some other media player resources it is the responsibility of
+ * the application to also release the media player factory at the appropriate time.
+ * <p>
+ * It is always a better strategy to reuse media player components, rather than repeatedly creating
+ * and destroying instances.
+ */
+public class StandaloneMediaPlayerWindow implements MediaPlayerEventListener, MouseListener, MouseMotionListener, MouseWheelListener, KeyListener {
+
+    /**
+     * Enumeration of flags for controller input (mouse and keyboard) event handling for the video
+     * surface.
+     */
+    public enum InputEvents {
+
+        /**
+         * No input event handling, no mouse or keyboard listener events will fire.
+         */
+        NONE,
+
+        /**
+         * Default input event handling, mouse and keyboard listener events will fire.
+         */
+        DEFAULT,
+
+        /**
+         * Disable native input event handling, mouse and keyboard listener events will fire.
+         * <p>
+         * This is the mode that is usually required on Windows.
+         */
+        DISABLE_NATIVE
+    }
+
+    /**
+     * Log.
+     */
+    private final Logger logger = LoggerFactory.getLogger(StandaloneMediaPlayerWindow.class);
+
+    /**
+     * Default factory initialisation arguments.
+     * <p>
+     * Sub-classes may totally disregard these arguments and provide their own.
+     * <p>
+     * A sub-class has access to these default arguments so new ones could be merged with these if
+     * required.
+     */
+    protected static final String[] DEFAULT_FACTORY_ARGUMENTS = {
+        "--video-title=vlcj video output",
+        "--no-snapshot-preview",
+        "--quiet-synchro",
+        "--sub-filter=logo:marq",
+        "--intf=dummy"
+    };
+
+    /**
+     * Media player factory.
+     */
+    private final MediaPlayerFactory mediaPlayerFactory;
+
+    /**
+     * Media player.
+     */
+    private final WindowedMediaPlayer mediaPlayer;
+
+    /**
+     * Video surface window.
+     */
+    private final Window window;
+
+    /**
+     * Video surface encapsulation.
+     */
+    private final WindowVideoSurface videoSurface;
+
+    /**
+     * Blank cursor to use when the cursor is disabled.
+     */
+    private Cursor blankCursor;
+
+    /**
+     * Construct a media player component.
+     * The window object must be visible.
+     */
+    public StandaloneMediaPlayerWindow(Window window) {
+        // Create the native resources
+        mediaPlayerFactory = onGetMediaPlayerFactory();
+        mediaPlayer = mediaPlayerFactory.newWindowedMediaPlayer(onGetFullScreenStrategy());
+        this.window = window;
+        videoSurface = mediaPlayerFactory.newVideoSurface(window);
+        mediaPlayer.setVideoSurface(videoSurface);
+        // Register listeners
+        mediaPlayer.addMediaPlayerEventListener(this);
+        switch (onGetInputEvents()) {
+            case NONE:
+                break;
+            case DISABLE_NATIVE:
+                mediaPlayer.setEnableKeyInputHandling(false);
+                mediaPlayer.setEnableMouseInputHandling(false);
+                // Case fall-through is by design
+            case DEFAULT:
+                window.addMouseListener(this);
+                window.addMouseMotionListener(this);
+                window.addMouseWheelListener(this);
+                window.addKeyListener(this);
+                break;
+        }
+        // Set the overlay
+        mediaPlayer.setOverlay(onGetOverlay());
+        // Sub-class initialisation
+        onAfterConstruct();
+    }
+
+    /**
+     * Get the media player factory reference.
+     *
+     * @return media player factory
+     */
+    public final MediaPlayerFactory getMediaPlayerFactory() {
+        return mediaPlayerFactory;
+    }
+
+    /**
+     * Get the embedded media player reference.
+     * <p>
+     * An application uses this handle to control the media player, add listeners and so on.
+     *
+     * @return media player
+     */
+    public final WindowedMediaPlayer getMediaPlayer() {
+        return mediaPlayer;
+    }
+
+    /**
+     * Get the video surface {@link Window} component.
+     * <p>
+     * An application may want to add key/mouse listeners to the video surface component.
+     *
+     * @return video surface component
+     */
+    public final Window getVideoSurface() {
+        return window;
+    }
+
+    /**
+     * Enable or disable the mouse cursor when it is over the component.
+     * <p>
+     * Note that you may see glitchy behaviour if you try and disable the cursor <em>after</em> you
+     * show the window/frame that contains your video surface.
+     * <p>
+     * If you want to disable the cursor for this component you should do so before you show the
+     * window.
+     *
+     * @param enabled <code>true</code> to enable (show) the cursor; <code>false</code> to disable (hide) it
+     */
+    public final void setCursorEnabled(boolean enabled) {
+        window.setCursor(enabled ? null : getBlankCursor());
+    }
+
+    /**
+     * Release the media player component and the associated native media player resources.
+     * <p>
+     * The associated media player factory will <em>not</em> be released, the client
+     * application is responsible for releasing the factory at the appropriate time.
+     */
+    public final void release() {
+        onBeforeRelease();
+        mediaPlayer.release();
+        onAfterRelease();
+    }
+
+    /**
+     * Release the media player component and the associated media player factory.
+     * <p>
+     * Optionally release the media player factory.
+     * <p>
+     * This method invokes {@link #release()}, then depending on the value of the <code>releaseFactory</code>
+     * parameter the associated factory will also be released.
+     *
+     * @param releaseFactory <code>true</code> if the factory should also be released; <code>false</code> if it should not
+     */
+    public final void release(boolean releaseFactory) {
+        logger.debug("release(releaseFactory={})", releaseFactory);
+        release();
+        if(releaseFactory) {
+            logger.debug("Releasing media player factory");
+            mediaPlayerFactory.release();
+        }
+    }
+
+    /**
+     * Create a blank 1x1 image to use when the cursor is disabled.
+     *
+     * @return cursor
+     */
+    private Cursor getBlankCursor() {
+        if(blankCursor == null) {
+            Image blankImage = new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB);
+            blankCursor = Toolkit.getDefaultToolkit().createCustomCursor(blankImage, new Point(0, 0), "");
+        }
+        return blankCursor;
+    }
+
+    /**
+     * Template method to create a media player factory.
+     * <p>
+     * The default implementation will invoke the {@link #onGetMediaPlayerFactoryArgs()} template
+     * method.
+     *
+     * @return media player factory
+     */
+    protected MediaPlayerFactory onGetMediaPlayerFactory() {
+        String[] args = Arguments.mergeArguments(onGetMediaPlayerFactoryArgs(), onGetMediaPlayerFactoryExtraArgs());
+        logger.debug("args={}", Arrays.toString(args));
+        return new MediaPlayerFactory(args);
+    }
+
+    /**
+     * Template method to obtain the initialisation arguments used to create the media player
+     * factory instance.
+     * <p>
+     * This can be used to provide arguments to use <em>instead</em> of the defaults.
+     * <p>
+     * If a sub-class overrides the {@link #onGetMediaPlayerFactory()} template method there is no
+     * guarantee that {@link #onGetMediaPlayerFactoryArgs()} will be called.
+     *
+     * @return media player factory initialisation arguments
+     */
+    protected String[] onGetMediaPlayerFactoryArgs() {
+        return DEFAULT_FACTORY_ARGUMENTS;
+    }
+
+    /**
+     * Template method to obtain the extra initialisation arguments used to create the media player
+     * factory instance.
+     * <p>
+     * This can be used to provide <em>additional</em> arguments to add to the hard-coded defaults.
+     * <p>
+     * If a sub-class overrides the {@link #onGetMediaPlayerFactory()} template method there is no
+     * guarantee that {@link #onGetMediaPlayerFactoryExtraArgs()} will be called.
+     *
+     * @return media player factory initialisation arguments, or <code>null</code>
+     */
+    protected String[] onGetMediaPlayerFactoryExtraArgs() {
+        return null;
+    }
+
+    /**
+     * Template method to obtain a full-screen strategy implementation.
+     * <p>
+     * The default implementation does not provide any full-screen strategy.
+     *
+     * @return full-screen strategy implementation
+     */
+    protected FullScreenStrategy onGetFullScreenStrategy() {
+        return null;
+    }
+
+    /**
+     * Template method to determine how input events should be processed by the component.
+     * <p>
+     * By default keyboard and mouse listener events from the video surface will be dispatched to
+     * the corresponding template methods in this component.
+     * <p>
+     * In addition, by Default on Windows the native input handling is disabled. This is usually
+     * what you always want if you want mouse and/or keyboard events from the video surface on
+     * Windows).
+     * <p>
+     * Override this method to change the default handling.
+     * <p>
+     * No matter what is chosen here, an application can still add its own listeners the usual way
+     * and can still choose to disable (or not) the native input handling.
+     *
+     * @return value describing how to handle input events, never <code>null</code>
+     */
+    protected InputEvents onGetInputEvents() {
+        if (RuntimeUtil.isNix() || RuntimeUtil.isMac()) {
+            return InputEvents.DEFAULT;
+        }
+        else {
+            return InputEvents.DISABLE_NATIVE;
+        }
+    }
+
+    /**
+     * Template method to obtain an overlay component.
+     * <p>
+     * The default implementation does not provide an overlay.
+     * <p>
+     * The overlay component may be a {@link Window} or a <code>Window</code> sub-class such as
+     * {@link JWindow}.
+     *
+     * @return overlay component
+     */
+    protected Window onGetOverlay() {
+        return null;
+    }
+
+    /**
+     * Template method invoked at the end of the media player constructor.
+     */
+    protected void onAfterConstruct() {
+    }
+
+    /**
+     * Template method invoked immediately prior to releasing the media player and media player
+     * factory instances.
+     */
+    protected void onBeforeRelease() {
+    }
+
+    /**
+     * Template method invoked immediately after releasing the media player and media player factory
+     * instances.
+     */
+    protected void onAfterRelease() {
+    }
+
+    // === MediaPlayerEventListener =============================================
+
+    @Override
+    public void mediaChanged(MediaPlayer mediaPlayer, libvlc_media_t media, String mrl) {
+    }
+
+    @Override
+    public void opening(MediaPlayer mediaPlayer) {
+    }
+
+    @Override
+    public void buffering(MediaPlayer mediaPlayer, float newCache) {
+    }
+
+    @Override
+    public void playing(MediaPlayer mediaPlayer) {
+    }
+
+    @Override
+    public void paused(MediaPlayer mediaPlayer) {
+    }
+
+    @Override
+    public void stopped(MediaPlayer mediaPlayer) {
+    }
+
+    @Override
+    public void forward(MediaPlayer mediaPlayer) {
+    }
+
+    @Override
+    public void backward(MediaPlayer mediaPlayer) {
+    }
+
+    @Override
+    public void finished(MediaPlayer mediaPlayer) {
+    }
+
+    @Override
+    public void timeChanged(MediaPlayer mediaPlayer, long newTime) {
+    }
+
+    @Override
+    public void positionChanged(MediaPlayer mediaPlayer, float newPosition) {
+    }
+
+    @Override
+    public void seekableChanged(MediaPlayer mediaPlayer, int newSeekable) {
+    }
+
+    @Override
+    public void pausableChanged(MediaPlayer mediaPlayer, int newSeekable) {
+    }
+
+    @Override
+    public void titleChanged(MediaPlayer mediaPlayer, int newTitle) {
+    }
+
+    @Override
+    public void snapshotTaken(MediaPlayer mediaPlayer, String filename) {
+    }
+
+    @Override
+    public void lengthChanged(MediaPlayer mediaPlayer, long newLength) {
+    }
+
+    @Override
+    public void videoOutput(MediaPlayer mediaPlayer, int newCount) {
+    }
+
+    @Override
+    public void scrambledChanged(MediaPlayer mediaPlayer, int newScrambled) {
+    }
+
+    @Override
+    public void elementaryStreamAdded(MediaPlayer mediaPlayer, int type, int id) {
+    }
+
+    @Override
+    public void elementaryStreamDeleted(MediaPlayer mediaPlayer, int type, int id) {
+    }
+
+    @Override
+    public void elementaryStreamSelected(MediaPlayer mediaPlayer, int type, int id) {
+    }
+
+    @Override
+    public void corked(MediaPlayer mediaPlayer, boolean corked) {
+    }
+
+    @Override
+    public void muted(MediaPlayer mediaPlayer, boolean muted) {
+    }
+
+    @Override
+    public void volumeChanged(MediaPlayer mediaPlayer, float volume) {
+    }
+
+    @Override
+    public void audioDeviceChanged(MediaPlayer mediaPlayer, String audioDevice) {
+    }
+
+    @Override
+    public void chapterChanged(MediaPlayer mediaPlayer, int newChapter) {
+    }
+
+    @Override
+    public void error(MediaPlayer mediaPlayer) {
+    }
+
+    @Override
+    public void mediaMetaChanged(MediaPlayer mediaPlayer, int metaType) {
+    }
+
+    @Override
+    public void mediaSubItemAdded(MediaPlayer mediaPlayer, libvlc_media_t subItem) {
+    }
+
+    @Override
+    public void mediaDurationChanged(MediaPlayer mediaPlayer, long newDuration) {
+    }
+
+    @Override
+    public void mediaParsedChanged(MediaPlayer mediaPlayer, int newStatus) {
+    }
+
+    @Override
+    public void mediaParsedStatus(MediaPlayer mediaPlayer, int newStatus) {
+    }
+
+    @Override
+    public void mediaFreed(MediaPlayer mediaPlayer) {
+    }
+
+    @Override
+    public void mediaStateChanged(MediaPlayer mediaPlayer, int newState) {
+    }
+
+    @Override
+    public void mediaSubItemTreeAdded(MediaPlayer mediaPlayer, libvlc_media_t item) {
+    }
+
+    @Override
+    public void newMedia(MediaPlayer mediaPlayer) {
+    }
+
+    @Override
+    public void subItemPlayed(MediaPlayer mediaPlayer, int subItemIndex) {
+    }
+
+    @Override
+    public void subItemFinished(MediaPlayer mediaPlayer, int subItemIndex) {
+    }
+
+    @Override
+    public void endOfSubItems(MediaPlayer mediaPlayer) {
+    }
+
+    // === MouseListener ========================================================
+
+    @Override
+    public void mouseClicked(MouseEvent e) {
+    }
+
+    @Override
+    public void mousePressed(MouseEvent e) {
+    }
+
+    @Override
+    public void mouseReleased(MouseEvent e) {
+    }
+
+    @Override
+    public void mouseEntered(MouseEvent e) {
+    }
+
+    @Override
+    public void mouseExited(MouseEvent e) {
+    }
+
+    // === MouseMotionListener ==================================================
+
+    @Override
+    public void mouseDragged(MouseEvent e) {
+    }
+
+    @Override
+    public void mouseMoved(MouseEvent e) {
+    }
+
+    // === MouseWheelListener ===================================================
+
+    @Override
+    public void mouseWheelMoved(MouseWheelEvent e) {
+    }
+
+    // === KeyListener ==========================================================
+
+    @Override
+    public void keyTyped(KeyEvent e) {
+    }
+
+    @Override
+    public void keyPressed(KeyEvent e) {
+    }
+
+    @Override
+    public void keyReleased(KeyEvent e) {
+    }
+}

--- a/src/main/java/uk/co/caprica/vlcj/player/MediaPlayerFactory.java
+++ b/src/main/java/uk/co/caprica/vlcj/player/MediaPlayerFactory.java
@@ -22,6 +22,7 @@ package uk.co.caprica.vlcj.player;
 import java.awt.Canvas;
 import java.awt.GraphicsEnvironment;
 import java.awt.Toolkit;
+import java.awt.Window;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.text.MessageFormat;
@@ -56,11 +57,14 @@ import uk.co.caprica.vlcj.player.directaudio.DefaultDirectAudioPlayer;
 import uk.co.caprica.vlcj.player.directaudio.DirectAudioPlayer;
 import uk.co.caprica.vlcj.player.discoverer.MediaDiscoverer;
 import uk.co.caprica.vlcj.player.embedded.DefaultEmbeddedMediaPlayer;
+import uk.co.caprica.vlcj.player.embedded.DefaultWindowedMediaPlayer;
 import uk.co.caprica.vlcj.player.embedded.EmbeddedMediaPlayer;
 import uk.co.caprica.vlcj.player.embedded.FullScreenStrategy;
+import uk.co.caprica.vlcj.player.embedded.WindowedMediaPlayer;
 import uk.co.caprica.vlcj.player.embedded.videosurface.CanvasVideoSurface;
 import uk.co.caprica.vlcj.player.embedded.videosurface.ComponentIdVideoSurface;
 import uk.co.caprica.vlcj.player.embedded.videosurface.VideoSurfaceAdapter;
+import uk.co.caprica.vlcj.player.embedded.videosurface.WindowVideoSurface;
 import uk.co.caprica.vlcj.player.embedded.videosurface.linux.LinuxVideoSurfaceAdapter;
 import uk.co.caprica.vlcj.player.embedded.videosurface.mac.MacVideoSurfaceAdapter;
 import uk.co.caprica.vlcj.player.embedded.videosurface.windows.WindowsVideoSurfaceAdapter;
@@ -677,6 +681,17 @@ public class MediaPlayerFactory {
         logger.debug("newEmbeddedMediaPlayer(fullScreenStrategy={})", fullScreenStrategy);
         return new DefaultEmbeddedMediaPlayer(libvlc, instance, fullScreenStrategy);
     }
+    
+    /**
+     * Create a new embedded media player.
+     *
+     * @param fullScreenStrategy full screen implementation, may be <code>null</code>
+     * @return media player instance
+     */
+    public WindowedMediaPlayer newWindowedMediaPlayer(FullScreenStrategy fullScreenStrategy) {
+	    	logger.debug("newWindowedMediaPlayer(fullScreenStrategy={})", fullScreenStrategy);
+	    	return new DefaultWindowedMediaPlayer(libvlc, instance, fullScreenStrategy);
+    }
 
     /**
      * Create a new direct video rendering media player.
@@ -754,6 +769,32 @@ public class MediaPlayerFactory {
         CanvasVideoSurface videoSurface = new CanvasVideoSurface(canvas, videoSurfaceAdapter);
         logger.debug("videoSurface={}", videoSurface);
         return videoSurface;
+    }
+
+    /**
+     * Create a new video surface from an AWT Window.
+     *
+     * @param window video surface
+     * @return video surface
+     */
+    public WindowVideoSurface newVideoSurface(Window window) {
+	    	logger.debug("newVideoSurface(canvas={})", window);
+	    	VideoSurfaceAdapter videoSurfaceAdapter;
+	    	if(RuntimeUtil.isNix()) {
+	    		videoSurfaceAdapter = new LinuxVideoSurfaceAdapter();
+	    	}
+	    	else if(RuntimeUtil.isWindows()) {
+	    		videoSurfaceAdapter = new WindowsVideoSurfaceAdapter();
+	    	}
+	    	else if(RuntimeUtil.isMac()) {
+	    		videoSurfaceAdapter = new MacVideoSurfaceAdapter();
+	    	}
+	    	else {
+	    		throw new RuntimeException("Unable to create a media player - failed to detect a supported operating system");
+	    	}
+	    	WindowVideoSurface videoSurface = new WindowVideoSurface(window, videoSurfaceAdapter);
+	    	logger.debug("videoSurface={}", videoSurface);
+	    	return videoSurface;
     }
 
     /**

--- a/src/main/java/uk/co/caprica/vlcj/player/embedded/DefaultWindowedMediaPlayer.java
+++ b/src/main/java/uk/co/caprica/vlcj/player/embedded/DefaultWindowedMediaPlayer.java
@@ -1,0 +1,396 @@
+/*
+ * This file is part of VLCJ.
+ *
+ * VLCJ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VLCJ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VLCJ.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2009-2016 Caprica Software Limited.
+ */
+
+package uk.co.caprica.vlcj.player.embedded;
+
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.Window;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.awt.image.BufferedImage;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import uk.co.caprica.vlcj.binding.LibVlc;
+import uk.co.caprica.vlcj.binding.internal.libvlc_instance_t;
+import uk.co.caprica.vlcj.player.DefaultMediaPlayer;
+import uk.co.caprica.vlcj.player.embedded.videosurface.WindowVideoSurface;
+
+/**
+ * Implementation of a media player that renders video to an AWT window.
+ * <p>
+ * This implementation supports the use of an 'overlay' window that will track the video surface
+ * position and size. Such an overlay could be used to paint custom graphics over the top of the
+ * video.
+ * <p>
+ * The overlay window should be non-opaque - support for this depends on the JVM, desktop window
+ * manager and graphics device hardware and software.
+ * <p>
+ * The overlay also has some significant limitations, it is a component that covers the video
+ * surface component and will prevent mouse and keyboard events from being processed by the video
+ * surface. Workarounds to delegate the mouse and keyboard events to the underlying Canvas may be
+ * possible but that is a responsibility of the overlay component itself and not these bindings.
+ * <p>
+ * The overlay will also 'lag' the main application frame when the frame is dragged - the event used
+ * to track the frame position does not fire until after the window drag operation has completed
+ * (i.e. the mouse pointer is released).
+ * <p>
+ * A further limitation is that the overlay will not appear when full-screen exclusive mode is used
+ * - if an overlay is required in full-screen mode then the full-screen mode must be simulated (by
+ * re-sizing the main window, removing decorations and so on).
+ * <p>
+ * If an overlay is used, then because the window is required to be non-opaque then it will appear
+ * in front of <strong>all</strong> other desktop windows, including application dialog windows. For
+ * this reason, it may be necessary to disable the overlay while displaying dialog boxes, or when
+ * the window is deactivated.
+ * <p>
+ * The overlay implementation in this class simply keeps a supplied window in sync with the video
+ * surface. It is the responsibility of the client application itself to supply an appropriate
+ * overlay component.
+ * <p>
+ * <strong>Finally, the overlay is experimental and support for the overlay may be changed or
+ * removed.</strong>
+ */
+public class DefaultWindowedMediaPlayer extends DefaultMediaPlayer implements WindowedMediaPlayer {
+
+    /**
+     * Log.
+     */
+    private final Logger logger = LoggerFactory.getLogger(DefaultWindowedMediaPlayer.class);
+
+    /**
+     * Full-screen strategy implementation, may be <code>null</code>.
+     */
+    private FullScreenStrategy fullScreenStrategy;
+
+    /**
+     * Listener implementation used to keep the overlay position and size in sync with the video
+     * surface.
+     */
+    private final OverlayComponentAdapter overlayComponentAdapter;
+
+    /**
+     * Listener implementation used to keep the overlay visibility state in sync with the video
+     * surface.
+     */
+    private final OverlayWindowAdapter overlayWindowAdapter;
+
+    /**
+     * Window to render the video to.
+     */
+    private WindowVideoSurface videoSurface;
+
+    /**
+     * Optional overlay component.
+     */
+    private Window overlay;
+
+    /**
+     * Track the requested overlay enabled/disabled state so it can be restored when needed.
+     */
+    private boolean requestedOverlay;
+
+    /**
+     * Track whether or not the overlay should be restored when the video surface is shown/hidden.
+     */
+    private boolean restoreOverlay;
+
+    /**
+     * Create a new media player.
+     * <p>
+     * Full-screen will not be supported.
+     *
+     * @param libvlc native interface
+     * @param instance libvlc instance
+     */
+    public DefaultWindowedMediaPlayer(LibVlc libvlc, libvlc_instance_t instance) {
+        this(libvlc, instance, null);
+    }
+
+    /**
+     * Create a new media player.
+     *
+     * @param libvlc native interface
+     * @param instance libvlc instance
+     * @param fullScreenStrategy full-screen strategy implementation
+     */
+    public DefaultWindowedMediaPlayer(LibVlc libvlc, libvlc_instance_t instance, FullScreenStrategy fullScreenStrategy) {
+        super(libvlc, instance);
+        this.fullScreenStrategy = fullScreenStrategy;
+        this.overlayComponentAdapter = new OverlayComponentAdapter();
+        this.overlayWindowAdapter = new OverlayWindowAdapter();
+    }
+
+    @Override
+    public void setVideoSurface(WindowVideoSurface videoSurface) {
+        logger.debug("setVideoSurface(videoSurface={})", videoSurface);
+        // Keep a hard reference to the video surface component
+        this.videoSurface = videoSurface;
+        // The video surface is not actually attached to the media player until the
+        // media is played
+    }
+
+    @Override
+    public void attachVideoSurface() {
+        logger.debug("attachVideoSurface()");
+        if(videoSurface != null) {
+            // The canvas component must be visible at this point otherwise the call
+            // to the native library will fail
+        		videoSurface.attach(libvlc, this);
+        }
+        else {
+            // This is not necessarily an error
+            logger.debug("Can't attach video surface since no video surface has been set");
+        }
+    }
+
+    @Override
+    public void setFullScreenStrategy(FullScreenStrategy fullScreenStrategy) {
+        logger.debug("setFullScreenStrategy(fullScreenStrategy={})", fullScreenStrategy);
+        this.fullScreenStrategy = fullScreenStrategy;
+    }
+
+    @Override
+    public void toggleFullScreen() {
+        logger.debug("toggleFullScreen()");
+        if(fullScreenStrategy != null) {
+            setFullScreen(!fullScreenStrategy.isFullScreenMode());
+        }
+    }
+
+    @Override
+    public void setFullScreen(boolean fullScreen) {
+        logger.debug("setFullScreen(fullScreen={})", fullScreen);
+        if(fullScreenStrategy != null) {
+            if(fullScreen) {
+                fullScreenStrategy.enterFullScreenMode();
+            }
+            else {
+                fullScreenStrategy.exitFullScreenMode();
+            }
+        }
+    }
+
+    @Override
+    public boolean isFullScreen() {
+        logger.debug("isFullScreen()");
+        if(fullScreenStrategy != null) {
+            return fullScreenStrategy.isFullScreenMode();
+        }
+        else {
+            return false;
+        }
+    }
+
+    @Override
+    public BufferedImage getVideoSurfaceContents() {
+        logger.debug("getVideoSurfaceContents()");
+        try {
+            Rectangle bounds = videoSurface.getWindow().getBounds();
+            bounds.setLocation(videoSurface.getWindow().getLocationOnScreen());
+            return new Robot().createScreenCapture(bounds);
+        }
+        catch(Exception e) {
+            throw new RuntimeException("Failed to get video surface contents", e);
+        }
+    }
+
+    @Override
+    public Window getOverlay() {
+        logger.debug("getOverlay()");
+        return overlay;
+    }
+
+    @Override
+    public void setOverlay(Window overlay) {
+        logger.debug("setOverlay(overlay={})", overlay);
+        if(videoSurface != null) {
+            // Disable the current overlay if there is one
+            enableOverlay(false);
+            // Remove the existing overlay if there is one
+            removeOverlay();
+            // Add the new overlay, but do not enable it
+            addOverlay(overlay);
+        }
+        else {
+            throw new IllegalStateException("Can't set an overlay when there's no video surface");
+        }
+    }
+
+    @Override
+    public void enableOverlay(boolean enable) {
+        logger.debug("enableOverlay(enable={})", enable);
+        requestedOverlay = enable;
+        if(overlay != null) {
+            if(enable) {
+                if(!overlay.isVisible()) {
+                    overlay.setLocation(videoSurface.getWindow().getLocationOnScreen());
+                    overlay.setSize(videoSurface.getWindow().getSize());
+                    videoSurface.getWindow().addComponentListener(overlayComponentAdapter);
+                    overlay.setVisible(true);
+                }
+            }
+            else {
+                if(overlay.isVisible()) {
+                    overlay.setVisible(false);
+                    videoSurface.getWindow().removeComponentListener(overlayComponentAdapter);
+                }
+            }
+        }
+    }
+
+    @Override
+    public boolean overlayEnabled() {
+        logger.debug("overlayEnabled()");
+        return overlay != null && overlay.isVisible();
+    }
+
+    @Override
+    public void setEnableMouseInputHandling(boolean enable) {
+        logger.debug("setEnableMouseInputHandling(enable={})", enable);
+        libvlc.libvlc_video_set_mouse_input(mediaPlayerInstance(), enable ? 1 : 0);
+    }
+
+    @Override
+    public void setEnableKeyInputHandling(boolean enable) {
+        logger.debug("setEnableKeyInputHandling(enable={})", enable);
+        libvlc.libvlc_video_set_key_input(mediaPlayerInstance(), enable ? 1 : 0);
+    }
+
+    /**
+     * Install an overlay component.
+     *
+     * @param overlay overlay window
+     */
+    private void addOverlay(Window overlay) {
+        logger.debug("addOverlay(overlay={})", overlay);
+        if(overlay != null) {
+            this.overlay = overlay;
+            videoSurface.getWindow().addWindowListener(overlayWindowAdapter);
+        }
+    }
+
+    /**
+     * Remove the overlay component.
+     *
+     * @param overlay overlay window
+     */
+    private void removeOverlay() {
+        logger.debug("removeOverlay()");
+        if(overlay != null) {
+            videoSurface.getWindow().removeWindowListener(overlayWindowAdapter);
+            overlay = null;
+        }
+    }
+
+    @Override
+    protected final void onBeforePlay() {
+        logger.debug("onBeforePlay()");
+        attachVideoSurface();
+    }
+
+    /**
+     * Component event listener to keep the overlay component in sync with the video surface
+     * component.
+     */
+    private final class OverlayComponentAdapter extends ComponentAdapter {
+
+        @Override
+        public void componentResized(ComponentEvent e) {
+            logger.trace("componentResized(e={})", e);
+            overlay.setSize(videoSurface.getWindow().getSize());
+        }
+
+        @Override
+        public void componentMoved(ComponentEvent e) {
+            logger.trace("componentMoved(e={})", e);
+            overlay.setLocation(videoSurface.getWindow().getLocationOnScreen());
+        }
+
+        @Override
+        public void componentShown(ComponentEvent e) {
+            logger.trace("componentShown(e={})", e);
+            showOverlay();
+        }
+
+        @Override
+        public void componentHidden(ComponentEvent e) {
+            logger.trace("componentHidden(e={})", e);
+            hideOverlay();
+        }
+    }
+
+    /**
+     * Window event listener to hide the overlay when the video window is hidden, and vice versa.
+     */
+    private final class OverlayWindowAdapter extends WindowAdapter {
+
+        @Override
+        public void windowIconified(WindowEvent e) {
+            logger.trace("windowIconified(e={})", e);
+            // Nothing, this is taken care of by "windowDeactivated"
+        }
+
+        @Override
+        public void windowDeiconified(WindowEvent e) {
+            logger.trace("windowDeiconified(e={})", e);
+            showOverlay();
+        }
+
+        @Override
+        public void windowDeactivated(WindowEvent e) {
+            logger.trace("windowDeactivated(e={})", e);
+            hideOverlay();
+        }
+
+        @Override
+        public void windowActivated(WindowEvent e) {
+            logger.trace("windowActivated(e={})", e);
+            showOverlay();
+        }
+    }
+
+    /**
+     * Make the overlay visible.
+     */
+    private void showOverlay() {
+        logger.trace("showOverlay()");
+        if(restoreOverlay) {
+            enableOverlay(true);
+        }
+    }
+
+    /**
+     * Hide the overlay.
+     */
+    private void hideOverlay() {
+        logger.trace("hideOverlay()");
+        if(requestedOverlay) {
+            restoreOverlay = true;
+            enableOverlay(false);
+        }
+        else {
+            restoreOverlay = false;
+        }
+    }
+}

--- a/src/main/java/uk/co/caprica/vlcj/player/embedded/WindowedMediaPlayer.java
+++ b/src/main/java/uk/co/caprica/vlcj/player/embedded/WindowedMediaPlayer.java
@@ -1,0 +1,205 @@
+/*
+ * This file is part of VLCJ.
+ *
+ * VLCJ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VLCJ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VLCJ.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2009-2016 Caprica Software Limited.
+ */
+
+package uk.co.caprica.vlcj.player.embedded;
+
+import java.awt.Window;
+import java.awt.image.BufferedImage;
+
+import uk.co.caprica.vlcj.player.MediaPlayer;
+import uk.co.caprica.vlcj.player.embedded.videosurface.WindowVideoSurface;
+
+/**
+ * Specification for a media player window that is intended to be show
+ * stand alone but not embedded.
+ * This is mainly useful for mac because after Oracle's JDK do not have heavy weight AWT components.
+ * And using {@link #DefaultEmbeddedMediaPlayer} may cause JVM crashing.
+ *  <p>
+ * Note that to get mouse and keyboard events delivered via listeners on some platforms (i.e. Windows)
+ * you will likely need to invoke {@link #setEnableMouseInputHandling(boolean)} <em>and</em>
+ * {@link #setEnableKeyInputHandling(boolean)}.
+ */
+public interface WindowedMediaPlayer extends MediaPlayer {
+
+    /**
+     * Set the component used to render video.
+     * <p>
+     * The video surface <em>must</em> be visible and fully realised before calling this
+     * method.
+     * <p>
+     * The video surface will not be associated with the native media player until the media is
+     * played.
+     * <p>
+     * It is possible to change the video surface after it has been set, but the change will not
+     * take effect until the media is played.
+     *
+     * @param videoSurface window to render video to
+     */
+    void setVideoSurface(WindowVideoSurface videoSurface);
+
+    /**
+     * Ensure that the video surface has been associated with the native media player.
+     * <p>
+     * Ordinarily when setting the video surface the actual association of the video surface with
+     * the native media player is deferred until the first time media is played.
+     * <p>
+     * This deferring behaviour is usually a good thing because when setting a video surface
+     * component on the native media player the video surface component must be a displayable
+     * component and this is often not the case during the construction and initialisation of the
+     * application.
+     * <p>
+     * Most applications will not need to call this method.
+     * <p>
+     * However, in special circumstances such as associating an embedded media player with a media
+     * list player, media is played through the media list rather than the media player itself so
+     * the deferred association of the video surface would never happen.
+     * <p>
+     * Calling this method ensures that the video surface is properly associated with the native
+     * media player and consequently the video surface component must be visible when this method is
+     * called.
+     */
+    void attachVideoSurface();
+
+    /**
+     * Set a full-screen strategy implementation.
+     * <p>
+     * The preferred way to set a full-screen strategy is via a constructor argument, nevertheless
+     * there are scenarios where it is more convenient to set the full-screen strategy <em>after</em>
+     * creation of the media player (depends how the application UI is created).
+     * <p>
+     * <em>Applications should not change the full-screen strategy implementation after initialisation
+     * of the media player. Doing so makes no practical sense and the resultant behaviour is
+     * undefined.</em>
+     *
+     * @param fullScreenStrategy full-screen strategy
+     */
+    void setFullScreenStrategy(FullScreenStrategy fullScreenStrategy);
+
+    /**
+     * Toggle whether the video display is in full-screen or not.
+     * <p>
+     * Setting the display into or out of full-screen mode is delegate to the
+     * {@link FullScreenStrategy} that was used when the media player was created.
+     */
+    void toggleFullScreen();
+
+    /**
+     * Set full-screen mode.
+     * <p>
+     * Setting the display into or out of full-screen mode is delegate to the
+     * {@link FullScreenStrategy} that was used when the media player was created.
+     *
+     * @param fullScreen true for full-screen, otherwise false
+     */
+    void setFullScreen(boolean fullScreen);
+
+    /**
+     * Check whether the full-screen mode is currently active or not.
+     * <p>
+     * Testing whether or not the display is in full-screen mode is delegate to the
+     * {@link FullScreenStrategy} that was used when the media player was created.
+     *
+     * @return true if full-screen is active, otherwise false
+     */
+    boolean isFullScreen();
+
+    /**
+     * Get the contents of the video surface component.
+     * <p>
+     * The implementation is expected to use the AWT Robot class to capture the contents of the
+     * video surface component (there is no other way).
+     * <p>
+     * The size of the returned image will match the current size of the video surface.
+     * <p>
+     * <strong>Since this implementation will use the AWT Robot class to make a screen capture, care
+     * must be taken when invoking this method to ensure that nothing else is overlaying the video
+     * surface!</strong>
+     *
+     * @return current contents of the video surface
+     */
+    BufferedImage getVideoSurfaceContents();
+
+    /**
+     * Get the overlay component.
+     *
+     * @return overlay component, may be <code>null</code>
+     */
+    Window getOverlay();
+
+    /**
+     * Set a new overlay component.
+     * <p>
+     * The existing overlay if there is one will be disabled.
+     * <p>
+     * The new overlay will <strong>not</strong> automatically be enabled.
+     * <p>
+     * The overlay should be a sub-class of <code>Window</code> or <code>JWindow</code>. If your
+     * overlay contains dynamically updated content such as a timer or animated graphics, then you
+     * should use <code>JWindow</code> so that your updates will be double-buffered and there will
+     * be no tearing or flickering when you paint the overlay. If you do this, you must take care to
+     * erase the overlay background before you paint it.
+     * <p>
+     * <strong>When the overlay is no longer needed it is your responsibility to {@link Window#dispose()}
+     * it - if you do not do this you may leak resources. If you set multiple different overlays you
+     * must remember to dispose the old overlay.</strong>
+     * <p>
+     * It is recommended to set the overlay once as early as possible in your application.
+     *
+     * @param overlay overlay component, may be <code>null</code>
+     */
+    void setOverlay(Window overlay);
+
+    /**
+     * Enable/disable the overlay component if there is one.
+     *
+     * @param enable whether to enable the overlay or disable it
+     */
+    void enableOverlay(boolean enable);
+
+    /**
+     * Check whether or not there is an overlay component currently enabled.
+     *
+     * @return true if there is an overlay enabled, otherwise false
+     */
+    boolean overlayEnabled();
+
+    /**
+     * Set whether or not to enable native media player mouse input handling.
+     * <p>
+     * It may be necessary on some platforms to invoke this method with a <code>false</code> parameter
+     * value for Java mouse and keyboard listeners to work.
+     * <p>
+     * Note that clicking the video surface on certain platforms is not guaranteed to capture mouse
+     * events - it may be necessary to respond to a mouse pressed event on the video surface and
+     * explicitly request the input focus to the video surface.
+     *
+     * @param enable <code>true</code> to enable, <code>false</code> to disable
+     */
+    void setEnableMouseInputHandling(boolean enable);
+
+    /**
+     * Set whether or not to enable native media player keyboard input handling.
+     * <p>
+     * It may be necessary on some platforms to invoke this method with a <code>false</code> parameter
+     * value for Java mouse and keyboard listeners to work.
+     *
+     * @param enable <code>true</code> to enable, <code>false</code> to disable
+     */
+    void setEnableKeyInputHandling(boolean enable);
+}

--- a/src/main/java/uk/co/caprica/vlcj/player/embedded/videosurface/WindowVideoSurface.java
+++ b/src/main/java/uk/co/caprica/vlcj/player/embedded/videosurface/WindowVideoSurface.java
@@ -1,0 +1,116 @@
+/*
+ * This file is part of VLCJ.
+ *
+ * VLCJ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VLCJ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VLCJ.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2009-2016 Caprica Software Limited.
+ */
+
+package uk.co.caprica.vlcj.player.embedded.videosurface;
+
+import java.awt.Window;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sun.jna.Native;
+
+import uk.co.caprica.vlcj.binding.LibVlc;
+import uk.co.caprica.vlcj.player.MediaPlayer;
+import uk.co.caprica.vlcj.runtime.RuntimeUtil;
+
+/**
+ * Encapsulation of a video surface that uses an AWT Window.
+ * This is only useful in MacOSX, do not use in other platforms.
+ * The window is to be show stand alone but not embedded.
+ * This is targeted at mac because Oracle's JDK do not have heavy weight AWT components.
+ * And using {@link #CanvasVideoSurface} may cause JVM crashing.
+ * This class provide a tricky way of getting AWT window's native id,
+ * so passing it to vlc-core will work.
+ */
+public class WindowVideoSurface extends VideoSurface {
+
+	/**
+	 * Log.
+	 */
+	private final Logger logger = LoggerFactory.getLogger(WindowVideoSurface.class);
+
+	/**
+	 * Serial version.
+	 */
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Video surface component.
+	 */
+	private final Window window;
+
+	/**
+	 * Create a new video surface.
+	 * The window must be visible.
+	 *
+	 * @param window video surface component
+	 * @param videoSurfaceAdapter adapter to attach a video surface to a native media player
+	 */
+	public WindowVideoSurface(Window window, VideoSurfaceAdapter videoSurfaceAdapter) {
+		super(videoSurfaceAdapter);
+		this.window = window;
+	}
+
+	/**
+	 * Get the awt window object
+	 * @return
+	 */
+	public Window getWindow() {
+		return window;
+	}
+
+	@Override
+	public void attach(LibVlc libvlc, MediaPlayer mediaPlayer) {
+		logger.debug("attach()");
+		if(window.isDisplayable()) {
+			long windowId = -1;
+			if (RuntimeUtil.isMac()) {
+				windowId = getNSWindowViewPtr(window);
+			}else {
+				windowId = Native.getWindowID(window);
+			}
+			logger.debug("windowId={}", windowId);
+			videoSurfaceAdapter.attach(libvlc, mediaPlayer, windowId);
+			logger.debug("video surface attached");
+		}
+		else {
+			throw new IllegalStateException("The video surface component must be displayable");
+		}
+	}
+
+	/**
+	 * Get native window ID in MacOSX
+	 * Not useful for other platforms.
+	 * @param window
+	 * @return -1 when fails
+	 */
+	public static long getNSWindowViewPtr(Window window) {
+		try {
+			Object componentPeer = window.getClass().getMethod("getPeer").invoke(window);
+			Object platformWindow = componentPeer.getClass().getMethod("getPlatformWindow").invoke(componentPeer);
+			Object contentView = platformWindow.getClass().getMethod("getContentView").invoke(platformWindow);
+			return (Long) contentView.getClass().getMethod("getAWTView").invoke(contentView);
+		} catch (Exception exception) {
+			exception.printStackTrace();
+			return -1;
+		}
+	}
+
+}


### PR DESCRIPTION
This is targeted at mac because Oracle's JDK do not have heavy weight
AWT components.And using CanvasVideoSurface may cause JVM crashing.
This commit provide a tricky way of getting AWT window's native id, and
make it easier for mac developers to use vlc.