### PR TITLE
Add additional discovery directories on Linux

### DIFF
--- a/src/main/java/uk/co/caprica/vlcj/discovery/linux/DefaultLinuxNativeDiscoveryStrategy.java
+++ b/src/main/java/uk/co/caprica/vlcj/discovery/linux/DefaultLinuxNativeDiscoveryStrategy.java
@@ -58,7 +58,11 @@ public class DefaultLinuxNativeDiscoveryStrategy extends StandardNativeDiscovery
 
     @Override
     protected void onGetDirectoryNames(List<String> directoryNames) {
-        directoryNames.add("/usr/lib");
-        directoryNames.add("/usr/local/lib");
+            directoryNames.add("/usr/lib");
+            directoryNames.add("/usr/lib64");
+            directoryNames.add("/usr/local/lib");
+            directoryNames.add("/usr/local/lib64");
+            directoryNames.add("/usr/lib/x86_64-linux-gnu");
+            directoryNames.add("/usr/lib/i386-linux-gnu");
     }
 }


### PR DESCRIPTION
We discovered from some user reports / testing that there's a few other common directories, particularly on Ubuntu, that can contain the VLC libs. We're just using these dirs in a custom discovery directory at present, but it seems like the sort of thing that would make sense in the root library.