### PR TITLE
+ fix: for the 'DiscoveryStrategy' implementations incorrectly matchi…

### DIFF
--- a/src/main/java/uk/co/caprica/vlcj/discovery/AbstractNativeDiscoveryStrategy.java
+++ b/src/main/java/uk/co/caprica/vlcj/discovery/AbstractNativeDiscoveryStrategy.java
@@ -89,18 +89,18 @@ public abstract class AbstractNativeDiscoveryStrategy implements NativeDiscovery
         File dir = new File(directoryName);
         File[] files = dir.listFiles();
         if(files != null) {
-            Pattern[] patternsToMatch = getFilenamePatterns();
-            int matchedCount = 0;
+            List<Pattern> patternsToMatch = new ArrayList<Pattern>(Arrays.asList(getFilenamePatterns()));
             for(File file : files) {
                 for(Pattern pattern : patternsToMatch) {
                     Matcher matcher = pattern.matcher(file.getName());
                     if(matcher.matches()) {
                         logger.debug("Matched '{}' in '{}'", file.getName(), directoryName);
-                        matchedCount++ ;
-                        if(matchedCount == patternsToMatch.length) {
+                        patternsToMatch.remove(pattern);
+                        if(patternsToMatch.isEmpty()) {
                             logger.debug("Matched all required files");
                             return true;
                         }
+                        break;
                     }
                 }
             }

--- a/src/test/java/uk/co/caprica/vlcj/test/discovery/CustomDiscoveryStrategy.java
+++ b/src/test/java/uk/co/caprica/vlcj/test/discovery/CustomDiscoveryStrategy.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of VLCJ.
+ *
+ * VLCJ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VLCJ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VLCJ.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2009-2018 Caprica Software Limited.
+ */
+
+package uk.co.caprica.vlcj.test.discovery;
+
+import java.util.List;
+
+import java.io.IOException;
+import java.io.File;
+
+import uk.co.caprica.vlcj.discovery.linux.DefaultLinuxNativeDiscoveryStrategy;
+
+/**
+ * @author daniel.kasmeroglu@kasisoft.net
+ */
+public class CustomDiscoveryStrategy extends DefaultLinuxNativeDiscoveryStrategy {
+
+    private void touch(File file) {
+        try {
+            file.createNewFile();
+        }
+        catch(IOException ex) {
+            throw new RuntimeException(ex);
+        }
+        if (!file.isFile()) {
+            throw new RuntimeException("Not a file: " + file.getAbsolutePath());
+        }
+    }
+    
+    @Override
+    protected void onGetDirectoryNames(List<String> directoryNames) {
+
+        // linux would require two libs: libvlccore and libvlc. we're only providing
+        // one here, so that library should be discovered
+        File tempDir = new File(System.getProperty("java.io.tmpdir"));
+        File pseudoLibDir = new File(tempDir, "custom-discovery-strategy");
+        pseudoLibDir.mkdirs();
+        if (!pseudoLibDir.isDirectory()) {
+            throw new RuntimeException("Not a file: " + pseudoLibDir.getAbsolutePath());
+        }
+        touch(new File(pseudoLibDir, "libvlc.so"));
+        touch(new File(pseudoLibDir, "libvlc.so.5"));
+        touch(new File(pseudoLibDir, "libvlc.so.5.6.0"));
+        directoryNames.add(pseudoLibDir.getAbsolutePath());
+        
+    }
+    
+    public static void main(String[] args) throws Exception {
+        CustomDiscoveryStrategy strategy   = new CustomDiscoveryStrategy();
+        String                  discovered = strategy.discover();
+        if (discovered != null) {
+            // we shouldn't discover something here
+            throw new RuntimeException("Detected library despite being  incomplete (" + discovered + ")");
+        }
+    }
+
+} /* ENDCLASS */


### PR DESCRIPTION
The added testcase 'CustomDiscoveryStrategy' creates a pseudo lib directory which shouldn't return a discovered path as 'libvlccore' is missing. Unfortunately the current implementation of the 'AbstractNativeDiscoveryStrategy' just counts the matches, so a pattern might match 'libvlc.so' as well as 'libvlc.so.5.6.0' which was unfortunately interpreted as the availability of both files.
My update just removes the patterns that had already been matched.

P.s: I'm not sure how to provide a testcase, so I hope it's okay this way. Otherwise it would be nice to get a pointer to related documentation. 
Btw.: Great work with this lib.