### PR TITLE
Change method name 'fov' to 'getFieldOfView'

### DIFF
--- a/src/main/java/uk/co/caprica/vlcj/player/base/Viewpoint.java
+++ b/src/main/java/uk/co/caprica/vlcj/player/base/Viewpoint.java
@@ -102,7 +102,7 @@ public final class Viewpoint {
      *
      * @return field of view, degrees
      */
-    public float fov() {
+    public float getFieldOfView() {
         return viewpoint.f_field_of_view;
     }
 


### PR DESCRIPTION
This class is used to represent ViewPoint.  This method named 'fov' is to get field of view. Thus, the method name 'getFieldOfView' is more intuitive than 'fov'.